### PR TITLE
Release/v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,6 @@ At `main/bebopfmt` there is a cli utility to format and rewrite bop files. It ta
 
 The following is a list of known issues with the current version of the project, ordered by approximate priority for addressing them.
 
-The Record interface could have two changes: 
-
-1. `Size() int`, essentially exposing the existing `bodySize` method. This would enable single allocations if working through and performing checks against each element in a list. 
-2. `MarshalBebopTo([]byte)` could return `n int` for how far into the byte slice the record was written.
-
 Original bebop does not support one .bop file importing type definitions from another .bop file, and so neither does this, yet.
 
 - This is nontrivial, and requires a lot of design toward the importing / packaging ecosystem.

--- a/bebop.go
+++ b/bebop.go
@@ -2,7 +2,7 @@
 package bebop
 
 // Version is the library version. Should be used by CLI tools when passed a '--version' flag.
-const Version = "v0.1.1"
+const Version = "v0.1.2"
 
 // A File is a structured representation of a .bop file.
 type File struct {

--- a/gen_test.go
+++ b/gen_test.go
@@ -1,10 +1,12 @@
 package bebop
 
 import (
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidateError(t *testing.T) {
@@ -96,6 +98,7 @@ var genTestFiles = []string{
 }
 
 func TestGenerateToFile(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
 	for _, filename := range genTestFiles {
 		filename := filename
 		t.Run(filename, func(t *testing.T) {
@@ -117,6 +120,7 @@ func TestGenerateToFile(t *testing.T) {
 			err = bopf.Generate(out, GenerateSettings{
 				PackageName:           "generated",
 				GenerateUnsafeMethods: true,
+				SharedMemoryStrings:   rand.Float64() < .5,
 			})
 			if err != nil {
 				t.Fatalf("generation failed: %v", err)

--- a/io.go
+++ b/io.go
@@ -12,7 +12,7 @@ type Record interface {
 	// MarshalBebopTo writes a bebop record to an existing byte slice. It is primarily
 	// used internally, and performs no checks to ensure the given byte slice is large
 	// enough to contain the record.
-	MarshalBebopTo([]byte)
+	MarshalBebopTo([]byte) (n int)
 	// UnmarshalBebop is parallel to Marshal as Decode is to Encode. It has similar
 	// performance improvements.
 	UnmarshalBebop([]byte) error
@@ -21,5 +21,9 @@ type Record interface {
 	// larger than a network packet and able to be acted upon as writer receives the byte
 	// stream, not only after the entire message has been received.
 	EncodeBebop(io.Writer) error
+	// DecodeBebop is to EncodeBebop as UnmarshlBebop is to MarshalBebop
 	DecodeBebop(io.Reader) error
+	// Size reports how many bytes a record takes up. It is only valid for the state of the
+	// record when Size is called.
+	Size() int
 }

--- a/iohelp/iohelp.go
+++ b/iohelp/iohelp.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"time"
+	"unsafe"
 )
 
 var ErrTooShort error = errors.New("buffer too short")
@@ -65,6 +66,12 @@ func MustReadStringBytes(buf []byte) string {
 	return string(buf[4 : 4+sz])
 }
 
+func MustReadStringBytesSharedMemory(buf []byte) string {
+	sz := ReadUint32Bytes(buf)
+	cut := buf[4 : 4+sz]
+	return *(*string)(unsafe.Pointer(&cut))
+}
+
 func ReadStringBytes(buf []byte) (string, error) {
 	if len(buf) < 4 {
 		return "", ErrTooShort
@@ -74,6 +81,18 @@ func ReadStringBytes(buf []byte) (string, error) {
 		return "", ErrTooShort
 	}
 	return string(buf[4 : 4+sz]), nil
+}
+
+func ReadStringBytesSharedMemory(buf []byte) (string, error) {
+	if len(buf) < 4 {
+		return "", ErrTooShort
+	}
+	sz := ReadUint32Bytes(buf)
+	if len(buf) < int(sz)+4 {
+		return "", ErrTooShort
+	}
+	cut := buf[4 : 4+sz]
+	return *(*string)(unsafe.Pointer(&cut)), nil
 }
 
 func ReadDate(r ErrorReader) time.Time {

--- a/main/bebopc-go/main.go
+++ b/main/bebopc-go/main.go
@@ -15,6 +15,7 @@ var printVersion = flag.Bool("version", false, "print the version of the compile
 var printHelp = flag.Bool("help", false, "print usage text")
 var packageName = flag.String("package", "bebopgen", "specify the name of the package to generate")
 var generateUnsafeMethods = flag.Bool("generate-unsafe", false, "whether unchecked additional methods should be generated")
+var shareStringMemory = flag.Bool("share-string-memory", false, "whether strings read in unmarshalling should share memory with the original byte slice")
 
 const version = "bebopc-go " + bebop.Version
 
@@ -61,6 +62,7 @@ func run() error {
 	settings := bebop.GenerateSettings{
 		PackageName:           *packageName,
 		GenerateUnsafeMethods: *generateUnsafeMethods,
+		SharedMemoryStrings:   *shareStringMemory,
 	}
 	if err := bopf.Generate(out, settings); err != nil {
 		return fmt.Errorf("failed to generate file: %w", err)

--- a/testdata/generated/array_of_strings.go
+++ b/testdata/generated/array_of_strings.go
@@ -16,12 +16,12 @@ type ArrayOfStrings struct {
 }
 
 func (bbp ArrayOfStrings) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp ArrayOfStrings) MarshalBebopTo(buf []byte) {
+func (bbp ArrayOfStrings) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.Strings)))
 	at += 4
@@ -31,6 +31,7 @@ func (bbp ArrayOfStrings) MarshalBebopTo(buf []byte) {
 		copy(buf[at:at+len(v1)], []byte(v1))
 		at += len(v1)
 	}
+	return at
 }
 
 func (bbp *ArrayOfStrings) UnmarshalBebop(buf []byte) (err error) {
@@ -41,7 +42,7 @@ func (bbp *ArrayOfStrings) UnmarshalBebop(buf []byte) (err error) {
 	bbp.Strings = make([]string, iohelp.ReadUint32Bytes(buf[at:]))
 	at += 4
 	for i1 := range bbp.Strings {
-		(bbp.Strings)[i1], err = iohelp.ReadStringBytes(buf[at:])
+		(bbp.Strings)[i1], err = iohelp.ReadStringBytesSharedMemory(buf[at:])
 		if err != nil {
 			 return err
 		}
@@ -55,7 +56,7 @@ func (bbp *ArrayOfStrings) MustUnmarshalBebop(buf []byte) {
 	bbp.Strings = make([]string, iohelp.ReadUint32Bytes(buf[at:]))
 	at += 4
 	for i1 := range bbp.Strings {
-		(bbp.Strings)[i1] = iohelp.MustReadStringBytes(buf[at:])
+		(bbp.Strings)[i1] =  iohelp.MustReadStringBytesSharedMemory(buf[at:])
 		at += 4+len((bbp.Strings)[i1])
 	}
 }
@@ -79,7 +80,7 @@ func (bbp *ArrayOfStrings) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp ArrayOfStrings) bodyLen() int {
+func (bbp ArrayOfStrings) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for _, elem := range bbp.Strings {

--- a/testdata/generated/basic_arrays.go
+++ b/testdata/generated/basic_arrays.go
@@ -27,12 +27,12 @@ type BasicArrays struct {
 }
 
 func (bbp BasicArrays) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp BasicArrays) MarshalBebopTo(buf []byte) {
+func (bbp BasicArrays) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A_bool)))
 	at += 4
@@ -106,6 +106,7 @@ func (bbp BasicArrays) MarshalBebopTo(buf []byte) {
 		iohelp.WriteGUIDBytes(buf[at:], v1)
 		at += 16
 	}
+	return at
 }
 
 func (bbp *BasicArrays) UnmarshalBebop(buf []byte) (err error) {
@@ -318,7 +319,7 @@ func (bbp *BasicArrays) MustUnmarshalBebop(buf []byte) {
 	bbp.A_string = make([]string, iohelp.ReadUint32Bytes(buf[at:]))
 	at += 4
 	for i1 := range bbp.A_string {
-		(bbp.A_string)[i1] = iohelp.MustReadStringBytes(buf[at:])
+		(bbp.A_string)[i1] =  iohelp.MustReadStringBytes(buf[at:])
 		at += 4+len((bbp.A_string)[i1])
 	}
 	bbp.A_guid = make([][16]byte, iohelp.ReadUint32Bytes(buf[at:]))
@@ -436,7 +437,7 @@ func (bbp *BasicArrays) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp BasicArrays) bodyLen() int {
+func (bbp BasicArrays) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A_bool) * 1
@@ -493,12 +494,12 @@ type TestInt32Array struct {
 }
 
 func (bbp TestInt32Array) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp TestInt32Array) MarshalBebopTo(buf []byte) {
+func (bbp TestInt32Array) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -506,6 +507,7 @@ func (bbp TestInt32Array) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt32Bytes(buf[at:], v1)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *TestInt32Array) UnmarshalBebop(buf []byte) (err error) {
@@ -553,7 +555,7 @@ func (bbp *TestInt32Array) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp TestInt32Array) bodyLen() int {
+func (bbp TestInt32Array) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 4

--- a/testdata/generated/basic_types.go
+++ b/testdata/generated/basic_types.go
@@ -29,12 +29,12 @@ type BasicTypes struct {
 }
 
 func (bbp BasicTypes) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp BasicTypes) MarshalBebopTo(buf []byte) {
+func (bbp BasicTypes) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteBoolBytes(buf[at:], bbp.A_bool)
 	at += 1
@@ -68,6 +68,7 @@ func (bbp BasicTypes) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt64Bytes(buf[at:], 0)
 	}
 	at += 8
+	return at
 }
 
 func (bbp *BasicTypes) UnmarshalBebop(buf []byte) (err error) {
@@ -122,7 +123,7 @@ func (bbp *BasicTypes) UnmarshalBebop(buf []byte) (err error) {
 	}
 	bbp.A_float64 = iohelp.ReadFloat64Bytes(buf[at:])
 	at += 8
-	bbp.A_string, err = iohelp.ReadStringBytes(buf[at:])
+	bbp.A_string, err = iohelp.ReadStringBytesSharedMemory(buf[at:])
 	if err != nil {
 		 return err
 	}
@@ -162,7 +163,7 @@ func (bbp *BasicTypes) MustUnmarshalBebop(buf []byte) {
 	at += 4
 	bbp.A_float64 = iohelp.ReadFloat64Bytes(buf[at:])
 	at += 8
-	bbp.A_string = iohelp.MustReadStringBytes(buf[at:])
+	bbp.A_string =  iohelp.MustReadStringBytesSharedMemory(buf[at:])
 	at += 4+len(bbp.A_string)
 	bbp.A_guid = iohelp.ReadGUIDBytes(buf[at:])
 	at += 16
@@ -211,7 +212,7 @@ func (bbp *BasicTypes) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp BasicTypes) bodyLen() int {
+func (bbp BasicTypes) Size() int {
 	bodyLen := 0
 	bodyLen += 1
 	bodyLen += 1

--- a/testdata/generated/date.go
+++ b/testdata/generated/date.go
@@ -19,14 +19,14 @@ type MyObj struct {
 }
 
 func (bbp MyObj) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp MyObj) MarshalBebopTo(buf []byte) {
+func (bbp MyObj) MarshalBebopTo(buf []byte) int {
 	at := 0
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-4))
 	at += 4
 	if bbp.Start != nil {
 		buf[at] = 1
@@ -48,6 +48,7 @@ func (bbp MyObj) MarshalBebopTo(buf []byte) {
 		}
 		at += 8
 	}
+	return at
 }
 
 func (bbp *MyObj) UnmarshalBebop(buf []byte) (err error) {
@@ -102,7 +103,7 @@ func (bbp *MyObj) MustUnmarshalBebop(buf []byte) {
 
 func (bbp MyObj) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-4))
 	if bbp.Start != nil {
 		w.Write([]byte{1})
 		if *bbp.Start != (time.Time{}) {
@@ -143,7 +144,7 @@ func (bbp *MyObj) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp MyObj) bodyLen() int {
+func (bbp MyObj) Size() int {
 	bodyLen := 5
 	if bbp.Start != nil {
 		bodyLen += 1

--- a/testdata/generated/documentation.go
+++ b/testdata/generated/documentation.go
@@ -39,15 +39,16 @@ type DocS struct {
 }
 
 func (bbp DocS) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp DocS) MarshalBebopTo(buf []byte) {
+func (bbp DocS) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.X)
 	at += 4
+	return at
 }
 
 func (bbp *DocS) UnmarshalBebop(buf []byte) (err error) {
@@ -78,7 +79,7 @@ func (bbp *DocS) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp DocS) bodyLen() int {
+func (bbp DocS) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	return bodyLen
@@ -110,14 +111,14 @@ type DepM struct {
 }
 
 func (bbp DepM) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp DepM) MarshalBebopTo(buf []byte) {
+func (bbp DepM) MarshalBebopTo(buf []byte) int {
 	at := 0
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-4))
 	at += 4
 	if bbp.X != nil {
 		buf[at] = 1
@@ -125,6 +126,7 @@ func (bbp DepM) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt32Bytes(buf[at:], *bbp.X)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *DepM) UnmarshalBebop(buf []byte) (err error) {
@@ -166,7 +168,7 @@ func (bbp *DepM) MustUnmarshalBebop(buf []byte) {
 
 func (bbp DepM) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-4))
 	if bbp.X != nil {
 		w.Write([]byte{1})
 		iohelp.WriteInt32(w, *bbp.X)
@@ -192,7 +194,7 @@ func (bbp *DepM) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp DepM) bodyLen() int {
+func (bbp DepM) Size() int {
 	bodyLen := 5
 	if bbp.X != nil {
 		bodyLen += 1
@@ -233,14 +235,14 @@ type DocM struct {
 }
 
 func (bbp DocM) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp DocM) MarshalBebopTo(buf []byte) {
+func (bbp DocM) MarshalBebopTo(buf []byte) int {
 	at := 0
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-4))
 	at += 4
 	if bbp.X != nil {
 		buf[at] = 1
@@ -260,6 +262,7 @@ func (bbp DocM) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt32Bytes(buf[at:], *bbp.Z)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *DocM) UnmarshalBebop(buf []byte) (err error) {
@@ -327,7 +330,7 @@ func (bbp *DocM) MustUnmarshalBebop(buf []byte) {
 
 func (bbp DocM) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-4))
 	if bbp.X != nil {
 		w.Write([]byte{1})
 		iohelp.WriteInt32(w, *bbp.X)
@@ -367,7 +370,7 @@ func (bbp *DocM) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp DocM) bodyLen() int {
+func (bbp DocM) Size() int {
 	bodyLen := 5
 	if bbp.X != nil {
 		bodyLen += 1

--- a/testdata/generated/foo.go
+++ b/testdata/generated/foo.go
@@ -17,15 +17,16 @@ type Foo struct {
 }
 
 func (bbp Foo) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp Foo) MarshalBebopTo(buf []byte) {
+func (bbp Foo) MarshalBebopTo(buf []byte) int {
 	at := 0
 	(bbp.Bar).MarshalBebopTo(buf[at:])
-	at += (bbp.Bar).bodyLen()
+	at += (bbp.Bar).Size()
+	return at
 }
 
 func (bbp *Foo) UnmarshalBebop(buf []byte) (err error) {
@@ -34,14 +35,14 @@ func (bbp *Foo) UnmarshalBebop(buf []byte) (err error) {
 	if err != nil {
 		 return err
 	}
-	at += (bbp.Bar).bodyLen()
+	at += (bbp.Bar).Size()
 	return nil
 }
 
 func (bbp *Foo) MustUnmarshalBebop(buf []byte) {
 	at := 0
 	bbp.Bar = mustMakeBarFromBytes(buf[at:])
-	at += (bbp.Bar).bodyLen()
+	at += (bbp.Bar).Size()
 }
 
 func (bbp Foo) EncodeBebop(iow io.Writer) (err error) {
@@ -62,9 +63,9 @@ func (bbp *Foo) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Foo) bodyLen() int {
+func (bbp Foo) Size() int {
 	bodyLen := 0
-	bodyLen += (bbp.Bar).bodyLen()
+	bodyLen += (bbp.Bar).Size()
 	return bodyLen
 }
 
@@ -95,14 +96,14 @@ type Bar struct {
 }
 
 func (bbp Bar) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp Bar) MarshalBebopTo(buf []byte) {
+func (bbp Bar) MarshalBebopTo(buf []byte) int {
 	at := 0
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-4))
 	at += 4
 	if bbp.X != nil {
 		buf[at] = 1
@@ -122,6 +123,7 @@ func (bbp Bar) MarshalBebopTo(buf []byte) {
 		iohelp.WriteFloat64Bytes(buf[at:], *bbp.Z)
 		at += 8
 	}
+	return at
 }
 
 func (bbp *Bar) UnmarshalBebop(buf []byte) (err error) {
@@ -189,7 +191,7 @@ func (bbp *Bar) MustUnmarshalBebop(buf []byte) {
 
 func (bbp Bar) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-4))
 	if bbp.X != nil {
 		w.Write([]byte{1})
 		iohelp.WriteFloat64(w, *bbp.X)
@@ -229,7 +231,7 @@ func (bbp *Bar) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp Bar) bodyLen() int {
+func (bbp Bar) Size() int {
 	bodyLen := 5
 	if bbp.X != nil {
 		bodyLen += 1

--- a/testdata/generated/lab.go
+++ b/testdata/generated/lab.go
@@ -24,12 +24,12 @@ type Int32s struct {
 }
 
 func (bbp Int32s) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp Int32s) MarshalBebopTo(buf []byte) {
+func (bbp Int32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -37,6 +37,7 @@ func (bbp Int32s) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt32Bytes(buf[at:], v1)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *Int32s) UnmarshalBebop(buf []byte) (err error) {
@@ -84,7 +85,7 @@ func (bbp *Int32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Int32s) bodyLen() int {
+func (bbp Int32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 4
@@ -116,12 +117,12 @@ type Uint32s struct {
 }
 
 func (bbp Uint32s) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp Uint32s) MarshalBebopTo(buf []byte) {
+func (bbp Uint32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -129,6 +130,7 @@ func (bbp Uint32s) MarshalBebopTo(buf []byte) {
 		iohelp.WriteUint32Bytes(buf[at:], v1)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *Uint32s) UnmarshalBebop(buf []byte) (err error) {
@@ -176,7 +178,7 @@ func (bbp *Uint32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Uint32s) bodyLen() int {
+func (bbp Uint32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 4
@@ -208,12 +210,12 @@ type Float32s struct {
 }
 
 func (bbp Float32s) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp Float32s) MarshalBebopTo(buf []byte) {
+func (bbp Float32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -221,6 +223,7 @@ func (bbp Float32s) MarshalBebopTo(buf []byte) {
 		iohelp.WriteFloat32Bytes(buf[at:], v1)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *Float32s) UnmarshalBebop(buf []byte) (err error) {
@@ -268,7 +271,7 @@ func (bbp *Float32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Float32s) bodyLen() int {
+func (bbp Float32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 4
@@ -300,12 +303,12 @@ type Int64s struct {
 }
 
 func (bbp Int64s) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp Int64s) MarshalBebopTo(buf []byte) {
+func (bbp Int64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -313,6 +316,7 @@ func (bbp Int64s) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt64Bytes(buf[at:], v1)
 		at += 8
 	}
+	return at
 }
 
 func (bbp *Int64s) UnmarshalBebop(buf []byte) (err error) {
@@ -360,7 +364,7 @@ func (bbp *Int64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Int64s) bodyLen() int {
+func (bbp Int64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 8
@@ -392,12 +396,12 @@ type Uint64s struct {
 }
 
 func (bbp Uint64s) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp Uint64s) MarshalBebopTo(buf []byte) {
+func (bbp Uint64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -405,6 +409,7 @@ func (bbp Uint64s) MarshalBebopTo(buf []byte) {
 		iohelp.WriteUint64Bytes(buf[at:], v1)
 		at += 8
 	}
+	return at
 }
 
 func (bbp *Uint64s) UnmarshalBebop(buf []byte) (err error) {
@@ -452,7 +457,7 @@ func (bbp *Uint64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Uint64s) bodyLen() int {
+func (bbp Uint64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 8
@@ -484,12 +489,12 @@ type Float64s struct {
 }
 
 func (bbp Float64s) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp Float64s) MarshalBebopTo(buf []byte) {
+func (bbp Float64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -497,6 +502,7 @@ func (bbp Float64s) MarshalBebopTo(buf []byte) {
 		iohelp.WriteFloat64Bytes(buf[at:], v1)
 		at += 8
 	}
+	return at
 }
 
 func (bbp *Float64s) UnmarshalBebop(buf []byte) (err error) {
@@ -544,7 +550,7 @@ func (bbp *Float64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Float64s) bodyLen() int {
+func (bbp Float64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 8
@@ -579,12 +585,12 @@ type VideoData struct {
 }
 
 func (bbp VideoData) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp VideoData) MarshalBebopTo(buf []byte) {
+func (bbp VideoData) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteFloat64Bytes(buf[at:], bbp.Time)
 	at += 8
@@ -596,6 +602,7 @@ func (bbp VideoData) MarshalBebopTo(buf []byte) {
 	at += 4
 	copy(buf[at:at+len(bbp.Fragment)], bbp.Fragment)
 	at += len(bbp.Fragment)
+	return at
 }
 
 func (bbp *VideoData) UnmarshalBebop(buf []byte) (err error) {
@@ -666,7 +673,7 @@ func (bbp *VideoData) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp VideoData) bodyLen() int {
+func (bbp VideoData) Size() int {
 	bodyLen := 0
 	bodyLen += 8
 	bodyLen += 4
@@ -702,14 +709,14 @@ type MediaMessage struct {
 }
 
 func (bbp MediaMessage) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp MediaMessage) MarshalBebopTo(buf []byte) {
+func (bbp MediaMessage) MarshalBebopTo(buf []byte) int {
 	at := 0
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-4))
 	at += 4
 	if bbp.Codec != nil {
 		buf[at] = 1
@@ -722,8 +729,9 @@ func (bbp MediaMessage) MarshalBebopTo(buf []byte) {
 		buf[at] = 2
 		at++
 		(*bbp.Data).MarshalBebopTo(buf[at:])
-		at += (*bbp.Data).bodyLen()
+		at += (*bbp.Data).Size()
 	}
+	return at
 }
 
 func (bbp *MediaMessage) UnmarshalBebop(buf []byte) (err error) {
@@ -745,7 +753,7 @@ func (bbp *MediaMessage) UnmarshalBebop(buf []byte) (err error) {
 			if err != nil {
 				 return err
 			}
-			at += ((*bbp.Data)).bodyLen()
+			at += ((*bbp.Data)).Size()
 		default:
 			return nil
 		}
@@ -768,7 +776,7 @@ func (bbp *MediaMessage) MustUnmarshalBebop(buf []byte) {
 			at += 1
 			bbp.Data = new(VideoData)
 			(*bbp.Data) = mustMakeVideoDataFromBytes(buf[at:])
-			at += ((*bbp.Data)).bodyLen()
+			at += ((*bbp.Data)).Size()
 		default:
 			return
 		}
@@ -777,7 +785,7 @@ func (bbp *MediaMessage) MustUnmarshalBebop(buf []byte) {
 
 func (bbp MediaMessage) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-4))
 	if bbp.Codec != nil {
 		w.Write([]byte{1})
 		iohelp.WriteUint32(w, uint32(*bbp.Codec))
@@ -816,7 +824,7 @@ func (bbp *MediaMessage) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp MediaMessage) bodyLen() int {
+func (bbp MediaMessage) Size() int {
 	bodyLen := 5
 	if bbp.Codec != nil {
 		bodyLen += 1
@@ -824,7 +832,7 @@ func (bbp MediaMessage) bodyLen() int {
 	}
 	if bbp.Data != nil {
 		bodyLen += 1
-		bodyLen += (*bbp.Data).bodyLen()
+		bodyLen += (*bbp.Data).Size()
 	}
 	return bodyLen
 }
@@ -856,14 +864,14 @@ type SkipTestOld struct {
 }
 
 func (bbp SkipTestOld) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp SkipTestOld) MarshalBebopTo(buf []byte) {
+func (bbp SkipTestOld) MarshalBebopTo(buf []byte) int {
 	at := 0
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-4))
 	at += 4
 	if bbp.X != nil {
 		buf[at] = 1
@@ -877,6 +885,7 @@ func (bbp SkipTestOld) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt32Bytes(buf[at:], *bbp.Y)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *SkipTestOld) UnmarshalBebop(buf []byte) (err error) {
@@ -931,7 +940,7 @@ func (bbp *SkipTestOld) MustUnmarshalBebop(buf []byte) {
 
 func (bbp SkipTestOld) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-4))
 	if bbp.X != nil {
 		w.Write([]byte{1})
 		iohelp.WriteInt32(w, *bbp.X)
@@ -964,7 +973,7 @@ func (bbp *SkipTestOld) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp SkipTestOld) bodyLen() int {
+func (bbp SkipTestOld) Size() int {
 	bodyLen := 5
 	if bbp.X != nil {
 		bodyLen += 1
@@ -1004,14 +1013,14 @@ type SkipTestNew struct {
 }
 
 func (bbp SkipTestNew) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp SkipTestNew) MarshalBebopTo(buf []byte) {
+func (bbp SkipTestNew) MarshalBebopTo(buf []byte) int {
 	at := 0
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-4))
 	at += 4
 	if bbp.X != nil {
 		buf[at] = 1
@@ -1031,6 +1040,7 @@ func (bbp SkipTestNew) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt32Bytes(buf[at:], *bbp.Z)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *SkipTestNew) UnmarshalBebop(buf []byte) (err error) {
@@ -1098,7 +1108,7 @@ func (bbp *SkipTestNew) MustUnmarshalBebop(buf []byte) {
 
 func (bbp SkipTestNew) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-4))
 	if bbp.X != nil {
 		w.Write([]byte{1})
 		iohelp.WriteInt32(w, *bbp.X)
@@ -1138,7 +1148,7 @@ func (bbp *SkipTestNew) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp SkipTestNew) bodyLen() int {
+func (bbp SkipTestNew) Size() int {
 	bodyLen := 5
 	if bbp.X != nil {
 		bodyLen += 1
@@ -1181,20 +1191,20 @@ type SkipTestOldContainer struct {
 }
 
 func (bbp SkipTestOldContainer) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp SkipTestOldContainer) MarshalBebopTo(buf []byte) {
+func (bbp SkipTestOldContainer) MarshalBebopTo(buf []byte) int {
 	at := 0
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-4))
 	at += 4
 	if bbp.S != nil {
 		buf[at] = 1
 		at++
 		(*bbp.S).MarshalBebopTo(buf[at:])
-		at += (*bbp.S).bodyLen()
+		at += (*bbp.S).Size()
 	}
 	if bbp.After != nil {
 		buf[at] = 2
@@ -1202,6 +1212,7 @@ func (bbp SkipTestOldContainer) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt32Bytes(buf[at:], *bbp.After)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *SkipTestOldContainer) UnmarshalBebop(buf []byte) (err error) {
@@ -1217,7 +1228,7 @@ func (bbp *SkipTestOldContainer) UnmarshalBebop(buf []byte) (err error) {
 			if err != nil {
 				 return err
 			}
-			at += ((*bbp.S)).bodyLen()
+			at += ((*bbp.S)).Size()
 		case 2:
 			at += 1
 			bbp.After = new(int32)
@@ -1242,7 +1253,7 @@ func (bbp *SkipTestOldContainer) MustUnmarshalBebop(buf []byte) {
 			at += 1
 			bbp.S = new(SkipTestOld)
 			(*bbp.S) = mustMakeSkipTestOldFromBytes(buf[at:])
-			at += ((*bbp.S)).bodyLen()
+			at += ((*bbp.S)).Size()
 		case 2:
 			at += 1
 			bbp.After = new(int32)
@@ -1256,7 +1267,7 @@ func (bbp *SkipTestOldContainer) MustUnmarshalBebop(buf []byte) {
 
 func (bbp SkipTestOldContainer) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-4))
 	if bbp.S != nil {
 		w.Write([]byte{1})
 		err = (*bbp.S).EncodeBebop(w)
@@ -1295,11 +1306,11 @@ func (bbp *SkipTestOldContainer) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp SkipTestOldContainer) bodyLen() int {
+func (bbp SkipTestOldContainer) Size() int {
 	bodyLen := 5
 	if bbp.S != nil {
 		bodyLen += 1
-		bodyLen += (*bbp.S).bodyLen()
+		bodyLen += (*bbp.S).Size()
 	}
 	if bbp.After != nil {
 		bodyLen += 1
@@ -1334,20 +1345,20 @@ type SkipTestNewContainer struct {
 }
 
 func (bbp SkipTestNewContainer) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp SkipTestNewContainer) MarshalBebopTo(buf []byte) {
+func (bbp SkipTestNewContainer) MarshalBebopTo(buf []byte) int {
 	at := 0
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-4))
 	at += 4
 	if bbp.S != nil {
 		buf[at] = 1
 		at++
 		(*bbp.S).MarshalBebopTo(buf[at:])
-		at += (*bbp.S).bodyLen()
+		at += (*bbp.S).Size()
 	}
 	if bbp.After != nil {
 		buf[at] = 2
@@ -1355,6 +1366,7 @@ func (bbp SkipTestNewContainer) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt32Bytes(buf[at:], *bbp.After)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *SkipTestNewContainer) UnmarshalBebop(buf []byte) (err error) {
@@ -1370,7 +1382,7 @@ func (bbp *SkipTestNewContainer) UnmarshalBebop(buf []byte) (err error) {
 			if err != nil {
 				 return err
 			}
-			at += ((*bbp.S)).bodyLen()
+			at += ((*bbp.S)).Size()
 		case 2:
 			at += 1
 			bbp.After = new(int32)
@@ -1395,7 +1407,7 @@ func (bbp *SkipTestNewContainer) MustUnmarshalBebop(buf []byte) {
 			at += 1
 			bbp.S = new(SkipTestNew)
 			(*bbp.S) = mustMakeSkipTestNewFromBytes(buf[at:])
-			at += ((*bbp.S)).bodyLen()
+			at += ((*bbp.S)).Size()
 		case 2:
 			at += 1
 			bbp.After = new(int32)
@@ -1409,7 +1421,7 @@ func (bbp *SkipTestNewContainer) MustUnmarshalBebop(buf []byte) {
 
 func (bbp SkipTestNewContainer) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-4))
 	if bbp.S != nil {
 		w.Write([]byte{1})
 		err = (*bbp.S).EncodeBebop(w)
@@ -1448,11 +1460,11 @@ func (bbp *SkipTestNewContainer) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp SkipTestNewContainer) bodyLen() int {
+func (bbp SkipTestNewContainer) Size() int {
 	bodyLen := 5
 	if bbp.S != nil {
 		bodyLen += 1
-		bodyLen += (*bbp.S).bodyLen()
+		bodyLen += (*bbp.S).Size()
 	}
 	if bbp.After != nil {
 		bodyLen += 1

--- a/testdata/generated/map_types.go
+++ b/testdata/generated/map_types.go
@@ -18,17 +18,18 @@ type S struct {
 }
 
 func (bbp S) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp S) MarshalBebopTo(buf []byte) {
+func (bbp S) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.x)
 	at += 4
 	iohelp.WriteInt32Bytes(buf[at:], bbp.y)
 	at += 4
+	return at
 }
 
 func (bbp *S) UnmarshalBebop(buf []byte) (err error) {
@@ -68,7 +69,7 @@ func (bbp *S) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp S) bodyLen() int {
+func (bbp S) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += 4
@@ -122,12 +123,12 @@ type SomeMaps struct {
 }
 
 func (bbp SomeMaps) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp SomeMaps) MarshalBebopTo(buf []byte) {
+func (bbp SomeMaps) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.M1)))
 	at += 4
@@ -174,7 +175,7 @@ func (bbp SomeMaps) MarshalBebopTo(buf []byte) {
 					iohelp.WriteBoolBytes(buf[at:], k4)
 					at += 1
 					(v4).MarshalBebopTo(buf[at:])
-					at += (v4).bodyLen()
+					at += (v4).Size()
 				}
 			}
 		}
@@ -203,8 +204,9 @@ func (bbp SomeMaps) MarshalBebopTo(buf []byte) {
 		iohelp.WriteGUIDBytes(buf[at:], k1)
 		at += 16
 		(v1).MarshalBebopTo(buf[at:])
-		at += (v1).bodyLen()
+		at += (v1).Size()
 	}
+	return at
 }
 
 func (bbp *SomeMaps) UnmarshalBebop(buf []byte) (err error) {
@@ -283,7 +285,7 @@ func (bbp *SomeMaps) UnmarshalBebop(buf []byte) (err error) {
 					if err != nil {
 						 return err
 					}
-					at += (((((bbp.M3)[i1])[k2])[i3])[k4]).bodyLen()
+					at += (((((bbp.M3)[i1])[k2])[i3])[k4]).Size()
 				}
 			}
 		}
@@ -330,7 +332,7 @@ func (bbp *SomeMaps) UnmarshalBebop(buf []byte) (err error) {
 		if err != nil {
 			 return err
 		}
-		at += ((bbp.M5)[k1]).bodyLen()
+		at += ((bbp.M5)[k1]).Size()
 	}
 	return nil
 }
@@ -350,15 +352,15 @@ func (bbp *SomeMaps) MustUnmarshalBebop(buf []byte) {
 	at += 4
 	bbp.M2 = make(map[string]map[string]string,ln11)
 	for i := uint32(0); i < ln11; i++ {
-		k1 := iohelp.MustReadStringBytes(buf[at:])
+		k1 :=  iohelp.MustReadStringBytes(buf[at:])
 		at += 4+len(k1)
 		ln12 := iohelp.ReadUint32Bytes(buf[at:])
 		at += 4
 		(bbp.M2)[k1] = make(map[string]string,ln12)
 		for i := uint32(0); i < ln12; i++ {
-			k2 := iohelp.MustReadStringBytes(buf[at:])
+			k2 :=  iohelp.MustReadStringBytes(buf[at:])
 			at += 4+len(k2)
-			((bbp.M2)[k1])[k2] = iohelp.MustReadStringBytes(buf[at:])
+			((bbp.M2)[k1])[k2] =  iohelp.MustReadStringBytes(buf[at:])
 			at += 4+len(((bbp.M2)[k1])[k2])
 		}
 	}
@@ -381,7 +383,7 @@ func (bbp *SomeMaps) MustUnmarshalBebop(buf []byte) {
 					k4 := iohelp.ReadBoolBytes(buf[at:])
 					at += 1
 					((((bbp.M3)[i1])[k2])[i3])[k4] = mustMakeSFromBytes(buf[at:])
-					at += (((((bbp.M3)[i1])[k2])[i3])[k4]).bodyLen()
+					at += (((((bbp.M3)[i1])[k2])[i3])[k4]).Size()
 				}
 			}
 		}
@@ -393,7 +395,7 @@ func (bbp *SomeMaps) MustUnmarshalBebop(buf []byte) {
 		at += 4
 		(bbp.M4)[i1] = make(map[string][]float32,ln15)
 		for i := uint32(0); i < ln15; i++ {
-			k2 := iohelp.MustReadStringBytes(buf[at:])
+			k2 :=  iohelp.MustReadStringBytes(buf[at:])
 			at += 4+len(k2)
 			((bbp.M4)[i1])[k2] = make([]float32, iohelp.ReadUint32Bytes(buf[at:]))
 			at += 4
@@ -410,7 +412,7 @@ func (bbp *SomeMaps) MustUnmarshalBebop(buf []byte) {
 		k1 := iohelp.ReadGUIDBytes(buf[at:])
 		at += 16
 		(bbp.M5)[k1] = mustMakeMFromBytes(buf[at:])
-		at += ((bbp.M5)[k1]).bodyLen()
+		at += ((bbp.M5)[k1]).Size()
 	}
 }
 
@@ -537,7 +539,7 @@ func (bbp *SomeMaps) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp SomeMaps) bodyLen() int {
+func (bbp SomeMaps) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for range bbp.M1 {
@@ -566,7 +568,7 @@ func (bbp SomeMaps) bodyLen() int {
 				bodyLen += 4
 				for _, v4 := range elem {
 					bodyLen += 1
-					bodyLen += (v4).bodyLen()
+					bodyLen += (v4).Size()
 				}
 			}
 		}
@@ -584,7 +586,7 @@ func (bbp SomeMaps) bodyLen() int {
 	bodyLen += 4
 	for _, v1 := range bbp.M5 {
 		bodyLen += 16
-		bodyLen += (v1).bodyLen()
+		bodyLen += (v1).Size()
 	}
 	return bodyLen
 }
@@ -615,14 +617,14 @@ type M struct {
 }
 
 func (bbp M) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp M) MarshalBebopTo(buf []byte) {
+func (bbp M) MarshalBebopTo(buf []byte) int {
 	at := 0
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-4))
 	at += 4
 	if bbp.A != nil {
 		buf[at] = 1
@@ -636,6 +638,7 @@ func (bbp M) MarshalBebopTo(buf []byte) {
 		iohelp.WriteFloat64Bytes(buf[at:], *bbp.B)
 		at += 8
 	}
+	return at
 }
 
 func (bbp *M) UnmarshalBebop(buf []byte) (err error) {
@@ -690,7 +693,7 @@ func (bbp *M) MustUnmarshalBebop(buf []byte) {
 
 func (bbp M) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-4))
 	if bbp.A != nil {
 		w.Write([]byte{1})
 		iohelp.WriteFloat32(w, *bbp.A)
@@ -723,7 +726,7 @@ func (bbp *M) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp M) bodyLen() int {
+func (bbp M) Size() int {
 	bodyLen := 5
 	if bbp.A != nil {
 		bodyLen += 1

--- a/testdata/generated/message_1.go
+++ b/testdata/generated/message_1.go
@@ -19,14 +19,14 @@ type ExampleMessage struct {
 }
 
 func (bbp ExampleMessage) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp ExampleMessage) MarshalBebopTo(buf []byte) {
+func (bbp ExampleMessage) MarshalBebopTo(buf []byte) int {
 	at := 0
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-4))
 	at += 4
 	if bbp.X != nil {
 		buf[at] = 1
@@ -46,6 +46,7 @@ func (bbp ExampleMessage) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt32Bytes(buf[at:], *bbp.Z)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *ExampleMessage) UnmarshalBebop(buf []byte) (err error) {
@@ -113,7 +114,7 @@ func (bbp *ExampleMessage) MustUnmarshalBebop(buf []byte) {
 
 func (bbp ExampleMessage) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-4))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-4))
 	if bbp.X != nil {
 		w.Write([]byte{1})
 		iohelp.WriteByte(w, *bbp.X)
@@ -153,7 +154,7 @@ func (bbp *ExampleMessage) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp ExampleMessage) bodyLen() int {
+func (bbp ExampleMessage) Size() int {
 	bodyLen := 5
 	if bbp.X != nil {
 		bodyLen += 1

--- a/testdata/generated/msgpack_comparison.go
+++ b/testdata/generated/msgpack_comparison.go
@@ -39,12 +39,12 @@ type MsgpackComparison struct {
 }
 
 func (bbp MsgpackComparison) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp MsgpackComparison) MarshalBebopTo(buf []byte) {
+func (bbp MsgpackComparison) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint8Bytes(buf[at:], bbp.INT0)
 	at += 1
@@ -112,6 +112,7 @@ func (bbp MsgpackComparison) MarshalBebopTo(buf []byte) {
 		iohelp.WriteInt32Bytes(buf[at:], v1)
 		at += 4
 	}
+	return at
 }
 
 func (bbp *MsgpackComparison) UnmarshalBebop(buf []byte) (err error) {
@@ -273,15 +274,15 @@ func (bbp *MsgpackComparison) MustUnmarshalBebop(buf []byte) {
 	at += 8
 	bbp.FLOAT_ = iohelp.ReadFloat64Bytes(buf[at:])
 	at += 8
-	bbp.STRING0 = iohelp.MustReadStringBytes(buf[at:])
+	bbp.STRING0 =  iohelp.MustReadStringBytes(buf[at:])
 	at += 4+len(bbp.STRING0)
-	bbp.STRING1 = iohelp.MustReadStringBytes(buf[at:])
+	bbp.STRING1 =  iohelp.MustReadStringBytes(buf[at:])
 	at += 4+len(bbp.STRING1)
-	bbp.STRING4 = iohelp.MustReadStringBytes(buf[at:])
+	bbp.STRING4 =  iohelp.MustReadStringBytes(buf[at:])
 	at += 4+len(bbp.STRING4)
-	bbp.STRING8 = iohelp.MustReadStringBytes(buf[at:])
+	bbp.STRING8 =  iohelp.MustReadStringBytes(buf[at:])
 	at += 4+len(bbp.STRING8)
-	bbp.STRING16 = iohelp.MustReadStringBytes(buf[at:])
+	bbp.STRING16 =  iohelp.MustReadStringBytes(buf[at:])
 	at += 4+len(bbp.STRING16)
 	bbp.ARRAY0 = make([]int32, iohelp.ReadUint32Bytes(buf[at:]))
 	at += 4
@@ -292,7 +293,7 @@ func (bbp *MsgpackComparison) MustUnmarshalBebop(buf []byte) {
 	bbp.ARRAY1 = make([]string, iohelp.ReadUint32Bytes(buf[at:]))
 	at += 4
 	for i1 := range bbp.ARRAY1 {
-		(bbp.ARRAY1)[i1] = iohelp.MustReadStringBytes(buf[at:])
+		(bbp.ARRAY1)[i1] =  iohelp.MustReadStringBytes(buf[at:])
 		at += 4+len((bbp.ARRAY1)[i1])
 	}
 	bbp.ARRAY8 = make([]int32, iohelp.ReadUint32Bytes(buf[at:]))
@@ -379,7 +380,7 @@ func (bbp *MsgpackComparison) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp MsgpackComparison) bodyLen() int {
+func (bbp MsgpackComparison) Size() int {
 	bodyLen := 0
 	bodyLen += 1
 	bodyLen += 1

--- a/testdata/generated/quoted_string.go
+++ b/testdata/generated/quoted_string.go
@@ -21,12 +21,12 @@ type QuotedString struct {
 }
 
 func (bbp QuotedString) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp QuotedString) MarshalBebopTo(buf []byte) {
+func (bbp QuotedString) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.X)
 	at += 4
@@ -34,6 +34,7 @@ func (bbp QuotedString) MarshalBebopTo(buf []byte) {
 	at += 4
 	iohelp.WriteInt32Bytes(buf[at:], bbp.Z)
 	at += 4
+	return at
 }
 
 func (bbp *QuotedString) UnmarshalBebop(buf []byte) (err error) {
@@ -82,7 +83,7 @@ func (bbp *QuotedString) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp QuotedString) bodyLen() int {
+func (bbp QuotedString) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += 4

--- a/testdata/generated/request.go
+++ b/testdata/generated/request.go
@@ -27,12 +27,12 @@ type Furniture struct {
 }
 
 func (bbp Furniture) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp Furniture) MarshalBebopTo(buf []byte) {
+func (bbp Furniture) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.name)))
 	at += 4
@@ -43,6 +43,7 @@ func (bbp Furniture) MarshalBebopTo(buf []byte) {
 	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.family))
 	at += 4
 	
+	return at
 }
 
 func (bbp *Furniture) UnmarshalBebop(buf []byte) (err error) {
@@ -65,7 +66,7 @@ func (bbp *Furniture) UnmarshalBebop(buf []byte) (err error) {
 
 func (bbp *Furniture) MustUnmarshalBebop(buf []byte) {
 	at := 0
-	bbp.name = iohelp.MustReadStringBytes(buf[at:])
+	bbp.name =  iohelp.MustReadStringBytes(buf[at:])
 	at += 4+len(bbp.name)
 	bbp.price = iohelp.ReadUint32Bytes(buf[at:])
 	at += 4
@@ -91,7 +92,7 @@ func (bbp *Furniture) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Furniture) bodyLen() int {
+func (bbp Furniture) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.name)
@@ -151,20 +152,21 @@ type RequestResponse struct {
 }
 
 func (bbp RequestResponse) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp RequestResponse) MarshalBebopTo(buf []byte) {
+func (bbp RequestResponse) MarshalBebopTo(buf []byte) int {
 	iohelp.WriteUint32Bytes(buf, uint32(RequestResponseOpCode))
 	at := 4
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.availableFurniture)))
 	at += 4
 	for _, v1 := range bbp.availableFurniture {
 		(v1).MarshalBebopTo(buf[at:])
-		at += (v1).bodyLen()
+		at += (v1).Size()
 	}
+	return at
 }
 
 func (bbp *RequestResponse) UnmarshalBebop(buf []byte) (err error) {
@@ -179,7 +181,7 @@ func (bbp *RequestResponse) UnmarshalBebop(buf []byte) (err error) {
 		if err != nil {
 			 return err
 		}
-		at += ((bbp.availableFurniture)[i1]).bodyLen()
+		at += ((bbp.availableFurniture)[i1]).Size()
 	}
 	return nil
 }
@@ -190,7 +192,7 @@ func (bbp *RequestResponse) MustUnmarshalBebop(buf []byte) {
 	at += 4
 	for i1 := range bbp.availableFurniture {
 		(bbp.availableFurniture)[i1] = mustMakeFurnitureFromBytes(buf[at:])
-		at += ((bbp.availableFurniture)[i1]).bodyLen()
+		at += ((bbp.availableFurniture)[i1]).Size()
 	}
 }
 
@@ -220,12 +222,12 @@ func (bbp *RequestResponse) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp RequestResponse) bodyLen() int {
+func (bbp RequestResponse) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += 4
 	for _, elem := range bbp.availableFurniture {
-		bodyLen += (elem).bodyLen()
+		bodyLen += (elem).Size()
 	}
 	return bodyLen
 }
@@ -271,15 +273,15 @@ type RequestCatalog struct {
 }
 
 func (bbp RequestCatalog) MarshalBebop() []byte {
-	buf := make([]byte, bbp.bodyLen())
+	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
 }
 
-func (bbp RequestCatalog) MarshalBebopTo(buf []byte) {
+func (bbp RequestCatalog) MarshalBebopTo(buf []byte) int {
 	iohelp.WriteUint32Bytes(buf, uint32(RequestCatalogOpCode))
 	at := 4
-	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.bodyLen()-8))
+	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Size()-8))
 	at += 4
 	if bbp.Family != nil {
 		buf[at] = 1
@@ -296,6 +298,7 @@ func (bbp RequestCatalog) MarshalBebopTo(buf []byte) {
 		copy(buf[at:at+len(*bbp.SecretTunnel)], []byte(*bbp.SecretTunnel))
 		at += len(*bbp.SecretTunnel)
 	}
+	return at
 }
 
 func (bbp *RequestCatalog) UnmarshalBebop(buf []byte) (err error) {
@@ -339,7 +342,7 @@ func (bbp *RequestCatalog) MustUnmarshalBebop(buf []byte) {
 		case 2:
 			at += 1
 			bbp.SecretTunnel = new(string)
-			(*bbp.SecretTunnel) = iohelp.MustReadStringBytes(buf[at:])
+			(*bbp.SecretTunnel) =  iohelp.MustReadStringBytes(buf[at:])
 			at += 4+len((*bbp.SecretTunnel))
 		default:
 			return
@@ -350,7 +353,7 @@ func (bbp *RequestCatalog) MustUnmarshalBebop(buf []byte) {
 func (bbp RequestCatalog) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(RequestCatalogOpCode))
-	iohelp.WriteUint32(w, uint32(bbp.bodyLen()-8))
+	iohelp.WriteUint32(w, uint32(bbp.Size()-8))
 	if bbp.Family != nil {
 		w.Write([]byte{1})
 		iohelp.WriteUint32(w, uint32(*bbp.Family))
@@ -385,7 +388,7 @@ func (bbp *RequestCatalog) DecodeBebop(ior io.Reader) (err error) {
 	}
 }
 
-func (bbp RequestCatalog) bodyLen() int {
+func (bbp RequestCatalog) Size() int {
 	bodyLen := 5
 	bodyLen += 4
 	if bbp.Family != nil {

--- a/testdata/generated/serve_test.go
+++ b/testdata/generated/serve_test.go
@@ -65,7 +65,7 @@ func TestServe(t *testing.T) {
 	}
 
 	resp := AddResponse{}
-	ln := resp.bodyLen()
+	ln := resp.Size()
 	respBytes := make([]byte, ln)
 	io.ReadFull(lhs, respBytes)
 	err = resp.UnmarshalBebop(respBytes)


### PR DESCRIPTION
This release
- Adds `Size() int` to `bebop.Record`
- Changes `MarshalBebopTo([]byte)` to return `int` of bytes written
- Adds  `SharedMemoryStrings` generation option to unmarshal functions, removing string allocations but sharing memory with the unmarshalling byte slice.