### PR TITLE
use ':' as meaningful tag comment separator instead of '='

### DIFF
--- a/bebop.go
+++ b/bebop.go
@@ -2,7 +2,7 @@
 package bebop
 
 // Version is the library version. Should be used by CLI tools when passed a '--version' flag.
-const Version = "v0.2.2"
+const Version = "v0.2.3"
 
 // A File is a structured representation of a .bop file.
 type File struct {

--- a/parse.go
+++ b/parse.go
@@ -732,23 +732,32 @@ func kindsStr(ks []tokenKind) string {
 }
 
 func parseCommentTag(s string) (Tag, bool) {
-	//[tag(json="example,omitempty")]
+	// OK
+	//[tag(json:"example,omitempty")]
+	//[tag(json:"more colons::")]
+	//[tag(boolean)]
+	// Not OK
+	// [tag(db:unquotedstring)]
+	// [tag()]
+	
 	if !strings.HasPrefix(s, "[tag(") || !strings.HasSuffix(s, ")]") {
 		return Tag{}, false
 	}
 	s = strings.TrimPrefix(s, "[tag(")
 	s = strings.TrimSuffix(s, ")]")
-	split := strings.Split(s, "=")
+	split := strings.Split(s, ":")
+	if len(split) == 0 {
+		return Tag{}, false
+	}
 	if len(split) == 1 {
 		return Tag{
 			Key:     split[0],
 			Boolean: true,
 		}, true
 	}
-	if len(split) != 2 {
-		return Tag{}, false
-	}
-	value, err := strconv.Unquote(split[1])
+	var err error
+	value := strings.Join(split[1:], "")
+	value, err = strconv.Unquote(value)
 	if err != nil {
 		return Tag{}, false
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -24,7 +24,7 @@ func TestReadFile(t *testing.T) {
 								FieldType: FieldType{
 									Simple: "string",
 								},
-								Comment: "[tag(json=\"foo,omitempty\")]",
+								Comment: "[tag(json:\"foo,omitempty\")]",
 								Tags: []Tag{
 									{
 										Key:   "json",
@@ -41,7 +41,7 @@ func TestReadFile(t *testing.T) {
 						Fields: map[uint8]Field{
 							1: {
 								Name:    "bar",
-								Comment: "[tag(db=\"bar\")]",
+								Comment: "[tag(db:\"bar\")]",
 								FieldType: FieldType{
 									Simple: "uint8",
 								},
@@ -76,14 +76,14 @@ func TestReadFile(t *testing.T) {
 								},
 								Struct: &Struct{
 									Name:    "TaggedSubStruct",
-									Comment: "[tag(one=\"one\")]\n[tag(two=\"two\")]\n[tag(boolean)]",
+									Comment: "[tag(one:\"one\")]\n[tag(two:\"two\")]\n[tag(boolean)]",
 									Fields: []Field{
 										{
 											Name: "biz",
 											FieldType: FieldType{
 												Simple: "guid",
 											},
-											Comment: "[tag(four=\"four\")]",
+											Comment: "[tag(four:\"four\")]",
 											Tags: []Tag{
 												{
 													Key:   "four",

--- a/testdata/base/tags.bop
+++ b/testdata/base/tags.bop
@@ -1,19 +1,19 @@
 struct TaggedStruct {
-    //[tag(json="foo,omitempty")]
+    //[tag(json:"foo,omitempty")]
     string foo;
 }
 
 message TaggedMessage {
-    //[tag(db="bar")]
+    //[tag(db:"bar")]
     1 -> uint8 bar;
 }
 
 union TaggedUnion {
-    //[tag(one="one")]
-    //[tag(two="two")]
+    //[tag(one:"one")]
+    //[tag(two:"two")]
     //[tag(boolean)]
     1 -> struct TaggedSubStruct {
-        //[tag(four="four")]
+        //[tag(four:"four")]
         guid biz;
     }   
 }


### PR DESCRIPTION
cf #14

Also bump to 0.2.3