### PR TITLE
Switch generated methods to pointer receivers

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -764,7 +764,7 @@ func writeWrappers(w io.Writer, name string, isEmpty bool, settings GenerateSett
 
 func writeMarshalBebop(w io.Writer, name string, isEmpty bool, settings GenerateSettings) {
 	exposedName := exposeName(name, settings)
-	writeLine(w, "func (bbp %s) MarshalBebop() []byte {", exposedName)
+	writeLine(w, "func (bbp *%s) MarshalBebop() []byte {", exposedName)
 	if isEmpty {
 		writeLine(w, "\treturn []byte{}")
 	} else {

--- a/gen_struct.go
+++ b/gen_struct.go
@@ -19,7 +19,7 @@ func (st Struct) generateTypeDefinition(w io.Writer, settings GenerateSettings) 
 
 func (st Struct) generateMarshalBebopTo(w io.Writer, settings GenerateSettings) {
 	exposedName := exposeName(st.Name, settings)
-	writeLine(w, "func (bbp %s) MarshalBebopTo(buf []byte) int {", exposedName)
+	writeLine(w, "func (bbp *%s) MarshalBebopTo(buf []byte) int {", exposedName)
 	startAt := "0"
 	if len(st.Fields) == 0 {
 		writeLine(w, "\treturn "+startAt)
@@ -74,7 +74,7 @@ func (st Struct) generateMustUnmarshalBebop(w io.Writer, settings GenerateSettin
 func (st Struct) generateEncodeBebop(w io.Writer, settings GenerateSettings) {
 	exposedName := exposeName(st.Name, settings)
 	*settings.isFirstTopLength = true
-	writeLine(w, "func (bbp %s) EncodeBebop(iow io.Writer) (err error) {", exposedName)
+	writeLine(w, "func (bbp *%s) EncodeBebop(iow io.Writer) (err error) {", exposedName)
 	if len(st.Fields) == 0 {
 		writeLine(w, "\treturn nil")
 	} else {
@@ -113,7 +113,7 @@ func (st Struct) generateDecodeBebop(w io.Writer, settings GenerateSettings) {
 
 func (st Struct) generateSize(w io.Writer, settings GenerateSettings) {
 	exposedName := exposeName(st.Name, settings)
-	writeLine(w, "func (bbp %s) Size() int {", exposedName)
+	writeLine(w, "func (bbp *%s) Size() int {", exposedName)
 	if len(st.Fields) == 0 {
 		writeLine(w, "\treturn 0")
 	} else {
@@ -135,7 +135,7 @@ func (st Struct) generateReadOnlyGetters(w io.Writer, settings GenerateSettings)
 	// TODO: slices are not read only, we need to return a copy.
 	exposedName := exposeName(st.Name, settings)
 	for _, fd := range st.Fields {
-		writeLine(w, "func (bbp %s) Get%s() %s {", exposedName, exposeName(fd.Name, settings), fd.FieldType.goString(settings))
+		writeLine(w, "func (bbp *%s) Get%s() %s {", exposedName, exposeName(fd.Name, settings), fd.FieldType.goString(settings))
 		writeLine(w, "\treturn bbp.%s", unexposeName(fd.Name))
 		writeCloseBlock(w)
 	}

--- a/testdata/generated-private/array_of_strings.go
+++ b/testdata/generated-private/array_of_strings.go
@@ -14,7 +14,7 @@ type arrayOfStrings struct {
 	strings []string
 }
 
-func (bbp arrayOfStrings) MarshalBebopTo(buf []byte) int {
+func (bbp *arrayOfStrings) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.strings)))
 	at += 4
@@ -53,7 +53,7 @@ func (bbp *arrayOfStrings) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp arrayOfStrings) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *arrayOfStrings) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.strings)))
 	for _, elem := range bbp.strings {
@@ -72,7 +72,7 @@ func (bbp *arrayOfStrings) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp arrayOfStrings) Size() int {
+func (bbp *arrayOfStrings) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for _, elem := range bbp.strings {
@@ -81,7 +81,7 @@ func (bbp arrayOfStrings) Size() int {
 	return bodyLen
 }
 
-func (bbp arrayOfStrings) MarshalBebop() []byte {
+func (bbp *arrayOfStrings) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/arrays.go
+++ b/testdata/generated-private/arrays.go
@@ -15,7 +15,7 @@ type arraySamples struct {
 	bytes2 [][][]byte
 }
 
-func (bbp arraySamples) MarshalBebopTo(buf []byte) int {
+func (bbp *arraySamples) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.bytes)))
 	at += 4
@@ -125,7 +125,7 @@ func (bbp *arraySamples) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp arraySamples) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *arraySamples) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.bytes)))
 	for _, elem := range bbp.bytes {
@@ -175,7 +175,7 @@ func (bbp *arraySamples) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp arraySamples) Size() int {
+func (bbp *arraySamples) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for _, elem := range bbp.bytes {
@@ -196,7 +196,7 @@ func (bbp arraySamples) Size() int {
 	return bodyLen
 }
 
-func (bbp arraySamples) MarshalBebop() []byte {
+func (bbp *arraySamples) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/basic_arrays.go
+++ b/testdata/generated-private/basic_arrays.go
@@ -25,7 +25,7 @@ type basicArrays struct {
 	a_guid [][16]byte
 }
 
-func (bbp basicArrays) MarshalBebopTo(buf []byte) int {
+func (bbp *basicArrays) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.a_bool)))
 	at += 4
@@ -322,7 +322,7 @@ func (bbp *basicArrays) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp basicArrays) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *basicArrays) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.a_bool)))
 	for _, elem := range bbp.a_bool {
@@ -429,7 +429,7 @@ func (bbp *basicArrays) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp basicArrays) Size() int {
+func (bbp *basicArrays) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.a_bool) * 1
@@ -460,7 +460,7 @@ func (bbp basicArrays) Size() int {
 	return bodyLen
 }
 
-func (bbp basicArrays) MarshalBebop() []byte {
+func (bbp *basicArrays) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -490,7 +490,7 @@ type testInt32Array struct {
 	a []int32
 }
 
-func (bbp testInt32Array) MarshalBebopTo(buf []byte) int {
+func (bbp *testInt32Array) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.a)))
 	at += 4
@@ -528,7 +528,7 @@ func (bbp *testInt32Array) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp testInt32Array) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *testInt32Array) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.a)))
 	for _, elem := range bbp.a {
@@ -546,14 +546,14 @@ func (bbp *testInt32Array) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp testInt32Array) Size() int {
+func (bbp *testInt32Array) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.a) * 4
 	return bodyLen
 }
 
-func (bbp testInt32Array) MarshalBebop() []byte {
+func (bbp *testInt32Array) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/basic_types.go
+++ b/testdata/generated-private/basic_types.go
@@ -27,7 +27,7 @@ type basicTypes struct {
 	a_date time.Time
 }
 
-func (bbp basicTypes) MarshalBebopTo(buf []byte) int {
+func (bbp *basicTypes) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteBoolBytes(buf[at:], bbp.a_bool)
 	at += 1
@@ -163,7 +163,7 @@ func (bbp *basicTypes) MustUnmarshalBebop(buf []byte) {
 	at += 8
 }
 
-func (bbp basicTypes) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *basicTypes) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteBool(w, bbp.a_bool)
 	iohelp.WriteByte(w, bbp.a_byte)
@@ -204,7 +204,7 @@ func (bbp *basicTypes) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp basicTypes) Size() int {
+func (bbp *basicTypes) Size() int {
 	bodyLen := 0
 	bodyLen += 1
 	bodyLen += 1
@@ -222,7 +222,7 @@ func (bbp basicTypes) Size() int {
 	return bodyLen
 }
 
-func (bbp basicTypes) MarshalBebop() []byte {
+func (bbp *basicTypes) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/date.go
+++ b/testdata/generated-private/date.go
@@ -148,7 +148,7 @@ func (bbp myObj) Size() int {
 	return bodyLen
 }
 
-func (bbp myObj) MarshalBebop() []byte {
+func (bbp *myObj) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/documentation.go
+++ b/testdata/generated-private/documentation.go
@@ -36,7 +36,7 @@ type docS struct {
 	x int32
 }
 
-func (bbp docS) MarshalBebopTo(buf []byte) int {
+func (bbp *docS) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.x)
 	at += 4
@@ -59,7 +59,7 @@ func (bbp *docS) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp docS) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *docS) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteInt32(w, bbp.x)
 	return w.Err
@@ -71,13 +71,13 @@ func (bbp *docS) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp docS) Size() int {
+func (bbp *docS) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp docS) MarshalBebop() []byte {
+func (bbp *docS) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -180,7 +180,7 @@ func (bbp depM) Size() int {
 	return bodyLen
 }
 
-func (bbp depM) MarshalBebop() []byte {
+func (bbp *depM) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -335,7 +335,7 @@ func (bbp docM) Size() int {
 	return bodyLen
 }
 
-func (bbp docM) MarshalBebop() []byte {
+func (bbp *docM) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/foo.go
+++ b/testdata/generated-private/foo.go
@@ -14,7 +14,7 @@ type foo struct {
 	bar bar
 }
 
-func (bbp foo) MarshalBebopTo(buf []byte) int {
+func (bbp *foo) MarshalBebopTo(buf []byte) int {
 	at := 0
 	(bbp.bar).MarshalBebopTo(buf[at:])
 	at += (bbp.bar).Size()
@@ -37,7 +37,7 @@ func (bbp *foo) MustUnmarshalBebop(buf []byte) {
 	at += (bbp.bar).Size()
 }
 
-func (bbp foo) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *foo) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	err = (bbp.bar).EncodeBebop(w)
 	if err != nil {
@@ -55,13 +55,13 @@ func (bbp *foo) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp foo) Size() int {
+func (bbp *foo) Size() int {
 	bodyLen := 0
 	bodyLen += (bbp.bar).Size()
 	return bodyLen
 }
 
-func (bbp foo) MarshalBebop() []byte {
+func (bbp *foo) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -239,7 +239,7 @@ func (bbp bar) Size() int {
 	return bodyLen
 }
 
-func (bbp bar) MarshalBebop() []byte {
+func (bbp *bar) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/jazz.go
+++ b/testdata/generated-private/jazz.go
@@ -23,7 +23,7 @@ type musician struct {
 	plays instrument
 }
 
-func (bbp musician) MarshalBebopTo(buf []byte) int {
+func (bbp *musician) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.name)))
 	copy(buf[at+4:at+4+len(bbp.name)], []byte(bbp.name))
@@ -53,7 +53,7 @@ func (bbp *musician) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp musician) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *musician) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.name)))
 	w.Write([]byte(bbp.name))
@@ -68,14 +68,14 @@ func (bbp *musician) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp musician) Size() int {
+func (bbp *musician) Size() int {
 	bodyLen := 0
 	bodyLen += 4 + len(bbp.name)
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp musician) MarshalBebop() []byte {
+func (bbp *musician) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -99,11 +99,11 @@ func mustMakemusicianFromBytes(buf []byte) musician {
 	return v
 }
 
-func (bbp musician) Getname() string {
+func (bbp *musician) Getname() string {
 	return bbp.name
 }
 
-func (bbp musician) Getplays() instrument {
+func (bbp *musician) Getplays() instrument {
 	return bbp.plays
 }
 
@@ -123,7 +123,7 @@ type library struct {
 	songs map[[16]byte]song
 }
 
-func (bbp library) MarshalBebopTo(buf []byte) int {
+func (bbp *library) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.songs)))
 	at += 4
@@ -169,7 +169,7 @@ func (bbp *library) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp library) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *library) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.songs)))
 	for k1, v1 := range bbp.songs {
@@ -196,7 +196,7 @@ func (bbp *library) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp library) Size() int {
+func (bbp *library) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for _, v1 := range bbp.songs {
@@ -206,7 +206,7 @@ func (bbp library) Size() int {
 	return bodyLen
 }
 
-func (bbp library) MarshalBebop() []byte {
+func (bbp *library) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -416,7 +416,7 @@ func (bbp song) Size() int {
 	return bodyLen
 }
 
-func (bbp song) MarshalBebop() []byte {
+func (bbp *song) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/lab.go
+++ b/testdata/generated-private/lab.go
@@ -21,7 +21,7 @@ type int32s struct {
 	a []int32
 }
 
-func (bbp int32s) MarshalBebopTo(buf []byte) int {
+func (bbp *int32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.a)))
 	at += 4
@@ -59,7 +59,7 @@ func (bbp *int32s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp int32s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *int32s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.a)))
 	for _, elem := range bbp.a {
@@ -77,14 +77,14 @@ func (bbp *int32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp int32s) Size() int {
+func (bbp *int32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.a) * 4
 	return bodyLen
 }
 
-func (bbp int32s) MarshalBebop() []byte {
+func (bbp *int32s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -114,7 +114,7 @@ type uint32s struct {
 	a []uint32
 }
 
-func (bbp uint32s) MarshalBebopTo(buf []byte) int {
+func (bbp *uint32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.a)))
 	at += 4
@@ -152,7 +152,7 @@ func (bbp *uint32s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp uint32s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *uint32s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.a)))
 	for _, elem := range bbp.a {
@@ -170,14 +170,14 @@ func (bbp *uint32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp uint32s) Size() int {
+func (bbp *uint32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.a) * 4
 	return bodyLen
 }
 
-func (bbp uint32s) MarshalBebop() []byte {
+func (bbp *uint32s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -207,7 +207,7 @@ type float32s struct {
 	a []float32
 }
 
-func (bbp float32s) MarshalBebopTo(buf []byte) int {
+func (bbp *float32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.a)))
 	at += 4
@@ -245,7 +245,7 @@ func (bbp *float32s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp float32s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *float32s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.a)))
 	for _, elem := range bbp.a {
@@ -263,14 +263,14 @@ func (bbp *float32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp float32s) Size() int {
+func (bbp *float32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.a) * 4
 	return bodyLen
 }
 
-func (bbp float32s) MarshalBebop() []byte {
+func (bbp *float32s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -300,7 +300,7 @@ type int64s struct {
 	a []int64
 }
 
-func (bbp int64s) MarshalBebopTo(buf []byte) int {
+func (bbp *int64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.a)))
 	at += 4
@@ -338,7 +338,7 @@ func (bbp *int64s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp int64s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *int64s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.a)))
 	for _, elem := range bbp.a {
@@ -356,14 +356,14 @@ func (bbp *int64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp int64s) Size() int {
+func (bbp *int64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.a) * 8
 	return bodyLen
 }
 
-func (bbp int64s) MarshalBebop() []byte {
+func (bbp *int64s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -393,7 +393,7 @@ type uint64s struct {
 	a []uint64
 }
 
-func (bbp uint64s) MarshalBebopTo(buf []byte) int {
+func (bbp *uint64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.a)))
 	at += 4
@@ -431,7 +431,7 @@ func (bbp *uint64s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp uint64s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *uint64s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.a)))
 	for _, elem := range bbp.a {
@@ -449,14 +449,14 @@ func (bbp *uint64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp uint64s) Size() int {
+func (bbp *uint64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.a) * 8
 	return bodyLen
 }
 
-func (bbp uint64s) MarshalBebop() []byte {
+func (bbp *uint64s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -486,7 +486,7 @@ type float64s struct {
 	a []float64
 }
 
-func (bbp float64s) MarshalBebopTo(buf []byte) int {
+func (bbp *float64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.a)))
 	at += 4
@@ -524,7 +524,7 @@ func (bbp *float64s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp float64s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *float64s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.a)))
 	for _, elem := range bbp.a {
@@ -542,14 +542,14 @@ func (bbp *float64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp float64s) Size() int {
+func (bbp *float64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.a) * 8
 	return bodyLen
 }
 
-func (bbp float64s) MarshalBebop() []byte {
+func (bbp *float64s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -582,7 +582,7 @@ type videoData struct {
 	fragment []byte
 }
 
-func (bbp videoData) MarshalBebopTo(buf []byte) int {
+func (bbp *videoData) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteFloat64Bytes(buf[at:], bbp.time)
 	at += 8
@@ -641,7 +641,7 @@ func (bbp *videoData) MustUnmarshalBebop(buf []byte) {
 	at += len(bbp.fragment)
 }
 
-func (bbp videoData) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *videoData) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteFloat64(w, bbp.time)
 	iohelp.WriteUint32(w, bbp.width)
@@ -665,7 +665,7 @@ func (bbp *videoData) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp videoData) Size() int {
+func (bbp *videoData) Size() int {
 	bodyLen := 0
 	bodyLen += 8
 	bodyLen += 4
@@ -675,7 +675,7 @@ func (bbp videoData) Size() int {
 	return bodyLen
 }
 
-func (bbp videoData) MarshalBebop() []byte {
+func (bbp *videoData) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -825,7 +825,7 @@ func (bbp mediaMessage) Size() int {
 	return bodyLen
 }
 
-func (bbp mediaMessage) MarshalBebop() []byte {
+func (bbp *mediaMessage) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -973,7 +973,7 @@ func (bbp skipTestOld) Size() int {
 	return bodyLen
 }
 
-func (bbp skipTestOld) MarshalBebop() []byte {
+func (bbp *skipTestOld) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -1151,7 +1151,7 @@ func (bbp skipTestNew) Size() int {
 	return bodyLen
 }
 
-func (bbp skipTestNew) MarshalBebop() []byte {
+func (bbp *skipTestNew) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -1304,7 +1304,7 @@ func (bbp skipTestOldContainer) Size() int {
 	return bodyLen
 }
 
-func (bbp skipTestOldContainer) MarshalBebop() []byte {
+func (bbp *skipTestOldContainer) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -1457,7 +1457,7 @@ func (bbp skipTestNewContainer) Size() int {
 	return bodyLen
 }
 
-func (bbp skipTestNewContainer) MarshalBebop() []byte {
+func (bbp *skipTestNewContainer) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/map_types.go
+++ b/testdata/generated-private/map_types.go
@@ -15,7 +15,7 @@ type s struct {
 	y int32
 }
 
-func (bbp s) MarshalBebopTo(buf []byte) int {
+func (bbp *s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.x)
 	at += 4
@@ -47,7 +47,7 @@ func (bbp *s) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteInt32(w, bbp.x)
 	iohelp.WriteInt32(w, bbp.y)
@@ -61,14 +61,14 @@ func (bbp *s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp s) Size() int {
+func (bbp *s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp s) MarshalBebop() []byte {
+func (bbp *s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -92,11 +92,11 @@ func mustMakesFromBytes(buf []byte) s {
 	return v
 }
 
-func (bbp s) Getx() int32 {
+func (bbp *s) Getx() int32 {
 	return bbp.x
 }
 
-func (bbp s) Gety() int32 {
+func (bbp *s) Gety() int32 {
 	return bbp.y
 }
 
@@ -120,7 +120,7 @@ type someMaps struct {
 	m5 map[[16]byte]m
 }
 
-func (bbp someMaps) MarshalBebopTo(buf []byte) int {
+func (bbp *someMaps) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.m1)))
 	at += 4
@@ -404,7 +404,7 @@ func (bbp *someMaps) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp someMaps) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *someMaps) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.m1)))
 	for k1, v1 := range bbp.m1 {
@@ -527,7 +527,7 @@ func (bbp *someMaps) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp someMaps) Size() int {
+func (bbp *someMaps) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for range bbp.m1 {
@@ -575,7 +575,7 @@ func (bbp someMaps) Size() int {
 	return bodyLen
 }
 
-func (bbp someMaps) MarshalBebop() []byte {
+func (bbp *someMaps) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -722,7 +722,7 @@ func (bbp m) Size() int {
 	return bodyLen
 }
 
-func (bbp m) MarshalBebop() []byte {
+func (bbp *m) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/message_1.go
+++ b/testdata/generated-private/message_1.go
@@ -162,7 +162,7 @@ func (bbp exampleMessage) Size() int {
 	return bodyLen
 }
 
-func (bbp exampleMessage) MarshalBebop() []byte {
+func (bbp *exampleMessage) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/message_map.go
+++ b/testdata/generated-private/message_map.go
@@ -138,7 +138,7 @@ func (bbp readOnlyMap) Size() int {
 	return bodyLen
 }
 
-func (bbp readOnlyMap) MarshalBebop() []byte {
+func (bbp *readOnlyMap) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/msgpack_comparison.go
+++ b/testdata/generated-private/msgpack_comparison.go
@@ -37,7 +37,7 @@ type msgpackComparison struct {
 	aRRAY8 []int32
 }
 
-func (bbp msgpackComparison) MarshalBebopTo(buf []byte) int {
+func (bbp *msgpackComparison) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint8Bytes(buf[at:], bbp.iNT0)
 	at += 1
@@ -291,7 +291,7 @@ func (bbp *msgpackComparison) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp msgpackComparison) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *msgpackComparison) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint8(w, bbp.iNT0)
 	iohelp.WriteUint8(w, bbp.iNT1)
@@ -367,7 +367,7 @@ func (bbp *msgpackComparison) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp msgpackComparison) Size() int {
+func (bbp *msgpackComparison) Size() int {
 	bodyLen := 0
 	bodyLen += 1
 	bodyLen += 1
@@ -398,7 +398,7 @@ func (bbp msgpackComparison) Size() int {
 	return bodyLen
 }
 
-func (bbp msgpackComparison) MarshalBebop() []byte {
+func (bbp *msgpackComparison) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/request.go
+++ b/testdata/generated-private/request.go
@@ -24,7 +24,7 @@ type furniture struct {
 	family furnitureFamily
 }
 
-func (bbp furniture) MarshalBebopTo(buf []byte) int {
+func (bbp *furniture) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.name)))
 	copy(buf[at+4:at+4+len(bbp.name)], []byte(bbp.name))
@@ -63,7 +63,7 @@ func (bbp *furniture) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp furniture) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *furniture) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.name)))
 	w.Write([]byte(bbp.name))
@@ -80,7 +80,7 @@ func (bbp *furniture) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp furniture) Size() int {
+func (bbp *furniture) Size() int {
 	bodyLen := 0
 	bodyLen += 4 + len(bbp.name)
 	bodyLen += 4
@@ -88,7 +88,7 @@ func (bbp furniture) Size() int {
 	return bodyLen
 }
 
-func (bbp furniture) MarshalBebop() []byte {
+func (bbp *furniture) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -112,15 +112,15 @@ func mustMakefurnitureFromBytes(buf []byte) furniture {
 	return v
 }
 
-func (bbp furniture) Getname() string {
+func (bbp *furniture) Getname() string {
 	return bbp.name
 }
 
-func (bbp furniture) Getprice() uint32 {
+func (bbp *furniture) Getprice() uint32 {
 	return bbp.price
 }
 
-func (bbp furniture) Getfamily() furnitureFamily {
+func (bbp *furniture) Getfamily() furnitureFamily {
 	return bbp.family
 }
 
@@ -144,7 +144,7 @@ type requestResponse struct {
 	availableFurniture []furniture
 }
 
-func (bbp requestResponse) MarshalBebopTo(buf []byte) int {
+func (bbp *requestResponse) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.availableFurniture)))
 	at += 4
@@ -182,7 +182,7 @@ func (bbp *requestResponse) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp requestResponse) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *requestResponse) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.availableFurniture)))
 	for _, elem := range bbp.availableFurniture {
@@ -206,7 +206,7 @@ func (bbp *requestResponse) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp requestResponse) Size() int {
+func (bbp *requestResponse) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for _, elem := range bbp.availableFurniture {
@@ -215,7 +215,7 @@ func (bbp requestResponse) Size() int {
 	return bodyLen
 }
 
-func (bbp requestResponse) MarshalBebop() []byte {
+func (bbp *requestResponse) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -239,7 +239,7 @@ func mustMakerequestResponseFromBytes(buf []byte) requestResponse {
 	return v
 }
 
-func (bbp requestResponse) GetavailableFurniture() []furniture {
+func (bbp *requestResponse) GetavailableFurniture() []furniture {
 	return bbp.availableFurniture
 }
 
@@ -360,7 +360,7 @@ func (bbp requestCatalog) Size() int {
 	return bodyLen
 }
 
-func (bbp requestCatalog) MarshalBebop() []byte {
+func (bbp *requestCatalog) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/server.go
+++ b/testdata/generated-private/server.go
@@ -14,7 +14,7 @@ type print struct {
 	printout string
 }
 
-func (bbp print) MarshalBebopTo(buf []byte) int {
+func (bbp *print) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.printout)))
 	copy(buf[at+4:at+4+len(bbp.printout)], []byte(bbp.printout))
@@ -38,7 +38,7 @@ func (bbp *print) MustUnmarshalBebop(buf []byte) {
 	at += 4 + len(bbp.printout)
 }
 
-func (bbp print) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *print) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.printout)))
 	w.Write([]byte(bbp.printout))
@@ -51,13 +51,13 @@ func (bbp *print) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp print) Size() int {
+func (bbp *print) Size() int {
 	bodyLen := 0
 	bodyLen += 4 + len(bbp.printout)
 	return bodyLen
 }
 
-func (bbp print) MarshalBebop() []byte {
+func (bbp *print) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -88,7 +88,7 @@ type add struct {
 	b int32
 }
 
-func (bbp add) MarshalBebopTo(buf []byte) int {
+func (bbp *add) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.a)
 	at += 4
@@ -120,7 +120,7 @@ func (bbp *add) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp add) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *add) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteInt32(w, bbp.a)
 	iohelp.WriteInt32(w, bbp.b)
@@ -134,14 +134,14 @@ func (bbp *add) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp add) Size() int {
+func (bbp *add) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp add) MarshalBebop() []byte {
+func (bbp *add) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -171,7 +171,7 @@ type addResponse struct {
 	c int32
 }
 
-func (bbp addResponse) MarshalBebopTo(buf []byte) int {
+func (bbp *addResponse) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.c)
 	at += 4
@@ -194,7 +194,7 @@ func (bbp *addResponse) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp addResponse) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *addResponse) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteInt32(w, bbp.c)
 	return w.Err
@@ -206,13 +206,13 @@ func (bbp *addResponse) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp addResponse) Size() int {
+func (bbp *addResponse) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp addResponse) MarshalBebop() []byte {
+func (bbp *addResponse) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -336,7 +336,7 @@ func (bbp printRequest) Size() int {
 	return bodyLen
 }
 
-func (bbp printRequest) MarshalBebop() []byte {
+func (bbp *printRequest) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -460,7 +460,7 @@ func (bbp addRequest) Size() int {
 	return bodyLen
 }
 
-func (bbp addRequest) MarshalBebop() []byte {
+func (bbp *addRequest) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/tags.go
+++ b/testdata/generated-private/tags.go
@@ -14,7 +14,7 @@ type taggedStruct struct {
 	foo string `json:"foo,omitempty"`
 }
 
-func (bbp taggedStruct) MarshalBebopTo(buf []byte) int {
+func (bbp *taggedStruct) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.foo)))
 	copy(buf[at+4:at+4+len(bbp.foo)], []byte(bbp.foo))
@@ -38,7 +38,7 @@ func (bbp *taggedStruct) MustUnmarshalBebop(buf []byte) {
 	at += 4 + len(bbp.foo)
 }
 
-func (bbp taggedStruct) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *taggedStruct) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.foo)))
 	w.Write([]byte(bbp.foo))
@@ -51,13 +51,13 @@ func (bbp *taggedStruct) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp taggedStruct) Size() int {
+func (bbp *taggedStruct) Size() int {
 	bodyLen := 0
 	bodyLen += 4 + len(bbp.foo)
 	return bodyLen
 }
 
-func (bbp taggedStruct) MarshalBebop() []byte {
+func (bbp *taggedStruct) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -173,7 +173,7 @@ func (bbp taggedMessage) Size() int {
 	return bodyLen
 }
 
-func (bbp taggedMessage) MarshalBebop() []byte {
+func (bbp *taggedMessage) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -203,7 +203,7 @@ type taggedSubStruct struct {
 	biz [16]byte `four:"four"`
 }
 
-func (bbp taggedSubStruct) MarshalBebopTo(buf []byte) int {
+func (bbp *taggedSubStruct) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteGUIDBytes(buf[at:], bbp.biz)
 	at += 16
@@ -226,7 +226,7 @@ func (bbp *taggedSubStruct) MustUnmarshalBebop(buf []byte) {
 	at += 16
 }
 
-func (bbp taggedSubStruct) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *taggedSubStruct) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteGUID(w, bbp.biz)
 	return w.Err
@@ -238,13 +238,13 @@ func (bbp *taggedSubStruct) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp taggedSubStruct) Size() int {
+func (bbp *taggedSubStruct) Size() int {
 	bodyLen := 0
 	bodyLen += 16
 	return bodyLen
 }
 
-func (bbp taggedSubStruct) MarshalBebop() []byte {
+func (bbp *taggedSubStruct) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -375,7 +375,7 @@ func (bbp taggedUnion) Size() int {
 	return bodyLen
 }
 
-func (bbp taggedUnion) MarshalBebop() []byte {
+func (bbp *taggedUnion) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/union.go
+++ b/testdata/generated-private/union.go
@@ -100,7 +100,7 @@ func (bbp a) Size() int {
 	return bodyLen
 }
 
-func (bbp a) MarshalBebop() []byte {
+func (bbp *a) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -133,7 +133,7 @@ type b struct {
 	c bool
 }
 
-func (bbp b) MarshalBebopTo(buf []byte) int {
+func (bbp *b) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteBoolBytes(buf[at:], bbp.c)
 	at += 1
@@ -156,7 +156,7 @@ func (bbp *b) MustUnmarshalBebop(buf []byte) {
 	at += 1
 }
 
-func (bbp b) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *b) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteBool(w, bbp.c)
 	return w.Err
@@ -168,13 +168,13 @@ func (bbp *b) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp b) Size() int {
+func (bbp *b) Size() int {
 	bodyLen := 0
 	bodyLen += 1
 	return bodyLen
 }
 
-func (bbp b) MarshalBebop() []byte {
+func (bbp *b) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -203,7 +203,7 @@ var _ bebop.Record = &c{}
 type c struct {
 }
 
-func (bbp c) MarshalBebopTo(buf []byte) int {
+func (bbp *c) MarshalBebopTo(buf []byte) int {
 	return 0
 }
 
@@ -214,7 +214,7 @@ func (bbp *c) UnmarshalBebop(buf []byte) (err error) {
 func (bbp *c) MustUnmarshalBebop(buf []byte) {
 }
 
-func (bbp c) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *c) EncodeBebop(iow io.Writer) (err error) {
 	return nil
 }
 
@@ -222,11 +222,11 @@ func (bbp *c) DecodeBebop(ior io.Reader) (err error) {
 	return nil
 }
 
-func (bbp c) Size() int {
+func (bbp *c) Size() int {
 	return 0
 }
 
-func (bbp c) MarshalBebop() []byte {
+func (bbp *c) MarshalBebop() []byte {
 	return []byte{}
 }
 
@@ -442,7 +442,7 @@ func (bbp u) Size() int {
 	return bodyLen
 }
 
-func (bbp u) MarshalBebop() []byte {
+func (bbp *u) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -473,7 +473,7 @@ type cons struct {
 	tail list
 }
 
-func (bbp cons) MarshalBebopTo(buf []byte) int {
+func (bbp *cons) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], bbp.head)
 	at += 4
@@ -505,7 +505,7 @@ func (bbp *cons) MustUnmarshalBebop(buf []byte) {
 	at += (bbp.tail).Size()
 }
 
-func (bbp cons) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *cons) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, bbp.head)
 	err = (bbp.tail).EncodeBebop(w)
@@ -525,14 +525,14 @@ func (bbp *cons) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp cons) Size() int {
+func (bbp *cons) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += (bbp.tail).Size()
 	return bodyLen
 }
 
-func (bbp cons) MarshalBebop() []byte {
+func (bbp *cons) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -562,7 +562,7 @@ var _ bebop.Record = &null{}
 type null struct {
 }
 
-func (bbp null) MarshalBebopTo(buf []byte) int {
+func (bbp *null) MarshalBebopTo(buf []byte) int {
 	return 0
 }
 
@@ -573,7 +573,7 @@ func (bbp *null) UnmarshalBebop(buf []byte) (err error) {
 func (bbp *null) MustUnmarshalBebop(buf []byte) {
 }
 
-func (bbp null) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *null) EncodeBebop(iow io.Writer) (err error) {
 	return nil
 }
 
@@ -581,11 +581,11 @@ func (bbp *null) DecodeBebop(ior io.Reader) (err error) {
 	return nil
 }
 
-func (bbp null) Size() int {
+func (bbp *null) Size() int {
 	return 0
 }
 
-func (bbp null) MarshalBebop() []byte {
+func (bbp *null) MarshalBebop() []byte {
 	return []byte{}
 }
 
@@ -752,7 +752,7 @@ func (bbp list) Size() int {
 	return bodyLen
 }
 
-func (bbp list) MarshalBebop() []byte {
+func (bbp *list) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated-private/union_field.go
+++ b/testdata/generated-private/union_field.go
@@ -106,7 +106,7 @@ func (bbp withUnionField) Size() int {
 	return bodyLen
 }
 
-func (bbp withUnionField) MarshalBebop() []byte {
+func (bbp *withUnionField) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -137,7 +137,7 @@ type cons2 struct {
 	tail list
 }
 
-func (bbp cons2) MarshalBebopTo(buf []byte) int {
+func (bbp *cons2) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], bbp.head)
 	at += 4
@@ -163,7 +163,7 @@ func (bbp *cons2) MustUnmarshalBebop(buf []byte) {
 	
 }
 
-func (bbp cons2) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *cons2) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, bbp.head)
 	
@@ -177,14 +177,14 @@ func (bbp *cons2) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp cons2) Size() int {
+func (bbp *cons2) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	
 	return bodyLen
 }
 
-func (bbp cons2) MarshalBebop() []byte {
+func (bbp *cons2) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -214,7 +214,7 @@ var _ bebop.Record = &nil2{}
 type nil2 struct {
 }
 
-func (bbp nil2) MarshalBebopTo(buf []byte) int {
+func (bbp *nil2) MarshalBebopTo(buf []byte) int {
 	return 0
 }
 
@@ -225,7 +225,7 @@ func (bbp *nil2) UnmarshalBebop(buf []byte) (err error) {
 func (bbp *nil2) MustUnmarshalBebop(buf []byte) {
 }
 
-func (bbp nil2) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *nil2) EncodeBebop(iow io.Writer) (err error) {
 	return nil
 }
 
@@ -233,11 +233,11 @@ func (bbp *nil2) DecodeBebop(ior io.Reader) (err error) {
 	return nil
 }
 
-func (bbp nil2) Size() int {
+func (bbp *nil2) Size() int {
 	return 0
 }
 
-func (bbp nil2) MarshalBebop() []byte {
+func (bbp *nil2) MarshalBebop() []byte {
 	return []byte{}
 }
 
@@ -404,7 +404,7 @@ func (bbp list2) Size() int {
 	return bodyLen
 }
 
-func (bbp list2) MarshalBebop() []byte {
+func (bbp *list2) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/array_of_strings.go
+++ b/testdata/generated/array_of_strings.go
@@ -14,7 +14,7 @@ type ArrayOfStrings struct {
 	Strings []string
 }
 
-func (bbp ArrayOfStrings) MarshalBebopTo(buf []byte) int {
+func (bbp *ArrayOfStrings) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.Strings)))
 	at += 4
@@ -53,7 +53,7 @@ func (bbp *ArrayOfStrings) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp ArrayOfStrings) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *ArrayOfStrings) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.Strings)))
 	for _, elem := range bbp.Strings {
@@ -72,7 +72,7 @@ func (bbp *ArrayOfStrings) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp ArrayOfStrings) Size() int {
+func (bbp *ArrayOfStrings) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for _, elem := range bbp.Strings {
@@ -81,7 +81,7 @@ func (bbp ArrayOfStrings) Size() int {
 	return bodyLen
 }
 
-func (bbp ArrayOfStrings) MarshalBebop() []byte {
+func (bbp *ArrayOfStrings) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/arrays.go
+++ b/testdata/generated/arrays.go
@@ -15,7 +15,7 @@ type ArraySamples struct {
 	Bytes2 [][][]byte
 }
 
-func (bbp ArraySamples) MarshalBebopTo(buf []byte) int {
+func (bbp *ArraySamples) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.Bytes)))
 	at += 4
@@ -125,7 +125,7 @@ func (bbp *ArraySamples) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp ArraySamples) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *ArraySamples) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.Bytes)))
 	for _, elem := range bbp.Bytes {
@@ -175,7 +175,7 @@ func (bbp *ArraySamples) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp ArraySamples) Size() int {
+func (bbp *ArraySamples) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for _, elem := range bbp.Bytes {
@@ -196,7 +196,7 @@ func (bbp ArraySamples) Size() int {
 	return bodyLen
 }
 
-func (bbp ArraySamples) MarshalBebop() []byte {
+func (bbp *ArraySamples) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/basic_arrays.go
+++ b/testdata/generated/basic_arrays.go
@@ -25,7 +25,7 @@ type BasicArrays struct {
 	A_guid [][16]byte
 }
 
-func (bbp BasicArrays) MarshalBebopTo(buf []byte) int {
+func (bbp *BasicArrays) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A_bool)))
 	at += 4
@@ -322,7 +322,7 @@ func (bbp *BasicArrays) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp BasicArrays) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *BasicArrays) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A_bool)))
 	for _, elem := range bbp.A_bool {
@@ -429,7 +429,7 @@ func (bbp *BasicArrays) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp BasicArrays) Size() int {
+func (bbp *BasicArrays) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A_bool) * 1
@@ -460,7 +460,7 @@ func (bbp BasicArrays) Size() int {
 	return bodyLen
 }
 
-func (bbp BasicArrays) MarshalBebop() []byte {
+func (bbp *BasicArrays) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -490,7 +490,7 @@ type TestInt32Array struct {
 	A []int32
 }
 
-func (bbp TestInt32Array) MarshalBebopTo(buf []byte) int {
+func (bbp *TestInt32Array) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -528,7 +528,7 @@ func (bbp *TestInt32Array) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp TestInt32Array) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *TestInt32Array) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -546,14 +546,14 @@ func (bbp *TestInt32Array) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp TestInt32Array) Size() int {
+func (bbp *TestInt32Array) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 4
 	return bodyLen
 }
 
-func (bbp TestInt32Array) MarshalBebop() []byte {
+func (bbp *TestInt32Array) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/basic_types.go
+++ b/testdata/generated/basic_types.go
@@ -27,7 +27,7 @@ type BasicTypes struct {
 	A_date time.Time
 }
 
-func (bbp BasicTypes) MarshalBebopTo(buf []byte) int {
+func (bbp *BasicTypes) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteBoolBytes(buf[at:], bbp.A_bool)
 	at += 1
@@ -163,7 +163,7 @@ func (bbp *BasicTypes) MustUnmarshalBebop(buf []byte) {
 	at += 8
 }
 
-func (bbp BasicTypes) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *BasicTypes) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteBool(w, bbp.A_bool)
 	iohelp.WriteByte(w, bbp.A_byte)
@@ -204,7 +204,7 @@ func (bbp *BasicTypes) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp BasicTypes) Size() int {
+func (bbp *BasicTypes) Size() int {
 	bodyLen := 0
 	bodyLen += 1
 	bodyLen += 1
@@ -222,7 +222,7 @@ func (bbp BasicTypes) Size() int {
 	return bodyLen
 }
 
-func (bbp BasicTypes) MarshalBebop() []byte {
+func (bbp *BasicTypes) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/date.go
+++ b/testdata/generated/date.go
@@ -148,7 +148,7 @@ func (bbp MyObj) Size() int {
 	return bodyLen
 }
 
-func (bbp MyObj) MarshalBebop() []byte {
+func (bbp *MyObj) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/documentation.go
+++ b/testdata/generated/documentation.go
@@ -36,7 +36,7 @@ type DocS struct {
 	X int32
 }
 
-func (bbp DocS) MarshalBebopTo(buf []byte) int {
+func (bbp *DocS) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.X)
 	at += 4
@@ -59,7 +59,7 @@ func (bbp *DocS) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp DocS) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *DocS) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteInt32(w, bbp.X)
 	return w.Err
@@ -71,13 +71,13 @@ func (bbp *DocS) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp DocS) Size() int {
+func (bbp *DocS) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp DocS) MarshalBebop() []byte {
+func (bbp *DocS) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -180,7 +180,7 @@ func (bbp DepM) Size() int {
 	return bodyLen
 }
 
-func (bbp DepM) MarshalBebop() []byte {
+func (bbp *DepM) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -335,7 +335,7 @@ func (bbp DocM) Size() int {
 	return bodyLen
 }
 
-func (bbp DocM) MarshalBebop() []byte {
+func (bbp *DocM) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/foo.go
+++ b/testdata/generated/foo.go
@@ -14,7 +14,7 @@ type Foo struct {
 	Bar Bar
 }
 
-func (bbp Foo) MarshalBebopTo(buf []byte) int {
+func (bbp *Foo) MarshalBebopTo(buf []byte) int {
 	at := 0
 	(bbp.Bar).MarshalBebopTo(buf[at:])
 	at += (bbp.Bar).Size()
@@ -37,7 +37,7 @@ func (bbp *Foo) MustUnmarshalBebop(buf []byte) {
 	at += (bbp.Bar).Size()
 }
 
-func (bbp Foo) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Foo) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	err = (bbp.Bar).EncodeBebop(w)
 	if err != nil {
@@ -55,13 +55,13 @@ func (bbp *Foo) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Foo) Size() int {
+func (bbp *Foo) Size() int {
 	bodyLen := 0
 	bodyLen += (bbp.Bar).Size()
 	return bodyLen
 }
 
-func (bbp Foo) MarshalBebop() []byte {
+func (bbp *Foo) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -239,7 +239,7 @@ func (bbp Bar) Size() int {
 	return bodyLen
 }
 
-func (bbp Bar) MarshalBebop() []byte {
+func (bbp *Bar) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/import_b/import_b.go
+++ b/testdata/generated/import_b/import_b.go
@@ -29,7 +29,7 @@ type Test22 struct {
 	Noisemaker Instrument
 }
 
-func (bbp Test22) MarshalBebopTo(buf []byte) int {
+func (bbp *Test22) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Noisemaker))
 	at += 4
@@ -49,7 +49,7 @@ func (bbp *Test22) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp Test22) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Test22) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(bbp.Noisemaker))
 	return w.Err
@@ -61,13 +61,13 @@ func (bbp *Test22) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Test22) Size() int {
+func (bbp *Test22) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp Test22) MarshalBebop() []byte {
+func (bbp *Test22) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -98,7 +98,7 @@ type Hello struct {
 	No string
 }
 
-func (bbp Hello) MarshalBebopTo(buf []byte) int {
+func (bbp *Hello) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.Yes)
 	at += 4
@@ -131,7 +131,7 @@ func (bbp *Hello) MustUnmarshalBebop(buf []byte) {
 	at += 4 + len(bbp.No)
 }
 
-func (bbp Hello) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Hello) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteInt32(w, bbp.Yes)
 	iohelp.WriteUint32(w, uint32(len(bbp.No)))
@@ -146,14 +146,14 @@ func (bbp *Hello) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Hello) Size() int {
+func (bbp *Hello) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += 4 + len(bbp.No)
 	return bodyLen
 }
 
-func (bbp Hello) MarshalBebop() []byte {
+func (bbp *Hello) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -184,7 +184,7 @@ type Musician struct {
 	plays Instrument
 }
 
-func (bbp Musician) MarshalBebopTo(buf []byte) int {
+func (bbp *Musician) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.name)))
 	copy(buf[at+4:at+4+len(bbp.name)], []byte(bbp.name))
@@ -214,7 +214,7 @@ func (bbp *Musician) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp Musician) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Musician) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.name)))
 	w.Write([]byte(bbp.name))
@@ -229,14 +229,14 @@ func (bbp *Musician) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Musician) Size() int {
+func (bbp *Musician) Size() int {
 	bodyLen := 0
 	bodyLen += 4 + len(bbp.name)
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp Musician) MarshalBebop() []byte {
+func (bbp *Musician) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -260,11 +260,11 @@ func MustMakeMusicianFromBytes(buf []byte) Musician {
 	return v
 }
 
-func (bbp Musician) GetName() string {
+func (bbp *Musician) GetName() string {
 	return bbp.name
 }
 
-func (bbp Musician) GetPlays() Instrument {
+func (bbp *Musician) GetPlays() Instrument {
 	return bbp.plays
 }
 
@@ -284,7 +284,7 @@ type Library struct {
 	Songs map[[16]byte]Song
 }
 
-func (bbp Library) MarshalBebopTo(buf []byte) int {
+func (bbp *Library) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.Songs)))
 	at += 4
@@ -330,7 +330,7 @@ func (bbp *Library) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Library) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Library) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.Songs)))
 	for k1, v1 := range bbp.Songs {
@@ -357,7 +357,7 @@ func (bbp *Library) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Library) Size() int {
+func (bbp *Library) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for _, v1 := range bbp.Songs {
@@ -367,7 +367,7 @@ func (bbp Library) Size() int {
 	return bodyLen
 }
 
-func (bbp Library) MarshalBebop() []byte {
+func (bbp *Library) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -397,7 +397,7 @@ type Int32s struct {
 	A []int32
 }
 
-func (bbp Int32s) MarshalBebopTo(buf []byte) int {
+func (bbp *Int32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -435,7 +435,7 @@ func (bbp *Int32s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Int32s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Int32s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -453,14 +453,14 @@ func (bbp *Int32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Int32s) Size() int {
+func (bbp *Int32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 4
 	return bodyLen
 }
 
-func (bbp Int32s) MarshalBebop() []byte {
+func (bbp *Int32s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -490,7 +490,7 @@ type Uint32s struct {
 	A []uint32
 }
 
-func (bbp Uint32s) MarshalBebopTo(buf []byte) int {
+func (bbp *Uint32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -528,7 +528,7 @@ func (bbp *Uint32s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Uint32s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Uint32s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -546,14 +546,14 @@ func (bbp *Uint32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Uint32s) Size() int {
+func (bbp *Uint32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 4
 	return bodyLen
 }
 
-func (bbp Uint32s) MarshalBebop() []byte {
+func (bbp *Uint32s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -583,7 +583,7 @@ type Float32s struct {
 	A []float32
 }
 
-func (bbp Float32s) MarshalBebopTo(buf []byte) int {
+func (bbp *Float32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -621,7 +621,7 @@ func (bbp *Float32s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Float32s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Float32s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -639,14 +639,14 @@ func (bbp *Float32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Float32s) Size() int {
+func (bbp *Float32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 4
 	return bodyLen
 }
 
-func (bbp Float32s) MarshalBebop() []byte {
+func (bbp *Float32s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -676,7 +676,7 @@ type Int64s struct {
 	A []int64
 }
 
-func (bbp Int64s) MarshalBebopTo(buf []byte) int {
+func (bbp *Int64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -714,7 +714,7 @@ func (bbp *Int64s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Int64s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Int64s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -732,14 +732,14 @@ func (bbp *Int64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Int64s) Size() int {
+func (bbp *Int64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 8
 	return bodyLen
 }
 
-func (bbp Int64s) MarshalBebop() []byte {
+func (bbp *Int64s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -769,7 +769,7 @@ type Uint64s struct {
 	A []uint64
 }
 
-func (bbp Uint64s) MarshalBebopTo(buf []byte) int {
+func (bbp *Uint64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -807,7 +807,7 @@ func (bbp *Uint64s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Uint64s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Uint64s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -825,14 +825,14 @@ func (bbp *Uint64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Uint64s) Size() int {
+func (bbp *Uint64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 8
 	return bodyLen
 }
 
-func (bbp Uint64s) MarshalBebop() []byte {
+func (bbp *Uint64s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -862,7 +862,7 @@ type Float64s struct {
 	A []float64
 }
 
-func (bbp Float64s) MarshalBebopTo(buf []byte) int {
+func (bbp *Float64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -900,7 +900,7 @@ func (bbp *Float64s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Float64s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Float64s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -918,14 +918,14 @@ func (bbp *Float64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Float64s) Size() int {
+func (bbp *Float64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 8
 	return bodyLen
 }
 
-func (bbp Float64s) MarshalBebop() []byte {
+func (bbp *Float64s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -958,7 +958,7 @@ type VideoData struct {
 	Fragment []byte
 }
 
-func (bbp VideoData) MarshalBebopTo(buf []byte) int {
+func (bbp *VideoData) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteFloat64Bytes(buf[at:], bbp.Time)
 	at += 8
@@ -1017,7 +1017,7 @@ func (bbp *VideoData) MustUnmarshalBebop(buf []byte) {
 	at += len(bbp.Fragment)
 }
 
-func (bbp VideoData) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *VideoData) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteFloat64(w, bbp.Time)
 	iohelp.WriteUint32(w, bbp.Width)
@@ -1041,7 +1041,7 @@ func (bbp *VideoData) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp VideoData) Size() int {
+func (bbp *VideoData) Size() int {
 	bodyLen := 0
 	bodyLen += 8
 	bodyLen += 4
@@ -1051,7 +1051,7 @@ func (bbp VideoData) Size() int {
 	return bodyLen
 }
 
-func (bbp VideoData) MarshalBebop() []byte {
+func (bbp *VideoData) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -1261,7 +1261,7 @@ func (bbp Song) Size() int {
 	return bodyLen
 }
 
-func (bbp Song) MarshalBebop() []byte {
+func (bbp *Song) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -1411,7 +1411,7 @@ func (bbp MediaMessage) Size() int {
 	return bodyLen
 }
 
-func (bbp MediaMessage) MarshalBebop() []byte {
+func (bbp *MediaMessage) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -1559,7 +1559,7 @@ func (bbp SkipTestOld) Size() int {
 	return bodyLen
 }
 
-func (bbp SkipTestOld) MarshalBebop() []byte {
+func (bbp *SkipTestOld) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -1737,7 +1737,7 @@ func (bbp SkipTestNew) Size() int {
 	return bodyLen
 }
 
-func (bbp SkipTestNew) MarshalBebop() []byte {
+func (bbp *SkipTestNew) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -1890,7 +1890,7 @@ func (bbp SkipTestOldContainer) Size() int {
 	return bodyLen
 }
 
-func (bbp SkipTestOldContainer) MarshalBebop() []byte {
+func (bbp *SkipTestOldContainer) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -2043,7 +2043,7 @@ func (bbp SkipTestNewContainer) Size() int {
 	return bodyLen
 }
 
-func (bbp SkipTestNewContainer) MarshalBebop() []byte {
+func (bbp *SkipTestNewContainer) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/jazz.go
+++ b/testdata/generated/jazz.go
@@ -23,7 +23,7 @@ type Musician struct {
 	plays Instrument
 }
 
-func (bbp Musician) MarshalBebopTo(buf []byte) int {
+func (bbp *Musician) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.name)))
 	copy(buf[at+4:at+4+len(bbp.name)], []byte(bbp.name))
@@ -53,7 +53,7 @@ func (bbp *Musician) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp Musician) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Musician) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.name)))
 	w.Write([]byte(bbp.name))
@@ -68,14 +68,14 @@ func (bbp *Musician) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Musician) Size() int {
+func (bbp *Musician) Size() int {
 	bodyLen := 0
 	bodyLen += 4 + len(bbp.name)
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp Musician) MarshalBebop() []byte {
+func (bbp *Musician) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -99,11 +99,11 @@ func MustMakeMusicianFromBytes(buf []byte) Musician {
 	return v
 }
 
-func (bbp Musician) GetName() string {
+func (bbp *Musician) GetName() string {
 	return bbp.name
 }
 
-func (bbp Musician) GetPlays() Instrument {
+func (bbp *Musician) GetPlays() Instrument {
 	return bbp.plays
 }
 
@@ -123,7 +123,7 @@ type Library struct {
 	Songs map[[16]byte]Song
 }
 
-func (bbp Library) MarshalBebopTo(buf []byte) int {
+func (bbp *Library) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.Songs)))
 	at += 4
@@ -169,7 +169,7 @@ func (bbp *Library) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Library) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Library) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.Songs)))
 	for k1, v1 := range bbp.Songs {
@@ -196,7 +196,7 @@ func (bbp *Library) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Library) Size() int {
+func (bbp *Library) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for _, v1 := range bbp.Songs {
@@ -206,7 +206,7 @@ func (bbp Library) Size() int {
 	return bodyLen
 }
 
-func (bbp Library) MarshalBebop() []byte {
+func (bbp *Library) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -416,7 +416,7 @@ func (bbp Song) Size() int {
 	return bodyLen
 }
 
-func (bbp Song) MarshalBebop() []byte {
+func (bbp *Song) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/lab.go
+++ b/testdata/generated/lab.go
@@ -21,7 +21,7 @@ type Int32s struct {
 	A []int32
 }
 
-func (bbp Int32s) MarshalBebopTo(buf []byte) int {
+func (bbp *Int32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -59,7 +59,7 @@ func (bbp *Int32s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Int32s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Int32s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -77,14 +77,14 @@ func (bbp *Int32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Int32s) Size() int {
+func (bbp *Int32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 4
 	return bodyLen
 }
 
-func (bbp Int32s) MarshalBebop() []byte {
+func (bbp *Int32s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -114,7 +114,7 @@ type Uint32s struct {
 	A []uint32
 }
 
-func (bbp Uint32s) MarshalBebopTo(buf []byte) int {
+func (bbp *Uint32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -152,7 +152,7 @@ func (bbp *Uint32s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Uint32s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Uint32s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -170,14 +170,14 @@ func (bbp *Uint32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Uint32s) Size() int {
+func (bbp *Uint32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 4
 	return bodyLen
 }
 
-func (bbp Uint32s) MarshalBebop() []byte {
+func (bbp *Uint32s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -207,7 +207,7 @@ type Float32s struct {
 	A []float32
 }
 
-func (bbp Float32s) MarshalBebopTo(buf []byte) int {
+func (bbp *Float32s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -245,7 +245,7 @@ func (bbp *Float32s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Float32s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Float32s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -263,14 +263,14 @@ func (bbp *Float32s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Float32s) Size() int {
+func (bbp *Float32s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 4
 	return bodyLen
 }
 
-func (bbp Float32s) MarshalBebop() []byte {
+func (bbp *Float32s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -300,7 +300,7 @@ type Int64s struct {
 	A []int64
 }
 
-func (bbp Int64s) MarshalBebopTo(buf []byte) int {
+func (bbp *Int64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -338,7 +338,7 @@ func (bbp *Int64s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Int64s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Int64s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -356,14 +356,14 @@ func (bbp *Int64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Int64s) Size() int {
+func (bbp *Int64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 8
 	return bodyLen
 }
 
-func (bbp Int64s) MarshalBebop() []byte {
+func (bbp *Int64s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -393,7 +393,7 @@ type Uint64s struct {
 	A []uint64
 }
 
-func (bbp Uint64s) MarshalBebopTo(buf []byte) int {
+func (bbp *Uint64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -431,7 +431,7 @@ func (bbp *Uint64s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Uint64s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Uint64s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -449,14 +449,14 @@ func (bbp *Uint64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Uint64s) Size() int {
+func (bbp *Uint64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 8
 	return bodyLen
 }
 
-func (bbp Uint64s) MarshalBebop() []byte {
+func (bbp *Uint64s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -486,7 +486,7 @@ type Float64s struct {
 	A []float64
 }
 
-func (bbp Float64s) MarshalBebopTo(buf []byte) int {
+func (bbp *Float64s) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.A)))
 	at += 4
@@ -524,7 +524,7 @@ func (bbp *Float64s) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp Float64s) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Float64s) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.A)))
 	for _, elem := range bbp.A {
@@ -542,14 +542,14 @@ func (bbp *Float64s) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Float64s) Size() int {
+func (bbp *Float64s) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += len(bbp.A) * 8
 	return bodyLen
 }
 
-func (bbp Float64s) MarshalBebop() []byte {
+func (bbp *Float64s) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -582,7 +582,7 @@ type VideoData struct {
 	Fragment []byte
 }
 
-func (bbp VideoData) MarshalBebopTo(buf []byte) int {
+func (bbp *VideoData) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteFloat64Bytes(buf[at:], bbp.Time)
 	at += 8
@@ -641,7 +641,7 @@ func (bbp *VideoData) MustUnmarshalBebop(buf []byte) {
 	at += len(bbp.Fragment)
 }
 
-func (bbp VideoData) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *VideoData) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteFloat64(w, bbp.Time)
 	iohelp.WriteUint32(w, bbp.Width)
@@ -665,7 +665,7 @@ func (bbp *VideoData) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp VideoData) Size() int {
+func (bbp *VideoData) Size() int {
 	bodyLen := 0
 	bodyLen += 8
 	bodyLen += 4
@@ -675,7 +675,7 @@ func (bbp VideoData) Size() int {
 	return bodyLen
 }
 
-func (bbp VideoData) MarshalBebop() []byte {
+func (bbp *VideoData) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -825,7 +825,7 @@ func (bbp MediaMessage) Size() int {
 	return bodyLen
 }
 
-func (bbp MediaMessage) MarshalBebop() []byte {
+func (bbp *MediaMessage) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -973,7 +973,7 @@ func (bbp SkipTestOld) Size() int {
 	return bodyLen
 }
 
-func (bbp SkipTestOld) MarshalBebop() []byte {
+func (bbp *SkipTestOld) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -1151,7 +1151,7 @@ func (bbp SkipTestNew) Size() int {
 	return bodyLen
 }
 
-func (bbp SkipTestNew) MarshalBebop() []byte {
+func (bbp *SkipTestNew) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -1304,7 +1304,7 @@ func (bbp SkipTestOldContainer) Size() int {
 	return bodyLen
 }
 
-func (bbp SkipTestOldContainer) MarshalBebop() []byte {
+func (bbp *SkipTestOldContainer) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -1457,7 +1457,7 @@ func (bbp SkipTestNewContainer) Size() int {
 	return bodyLen
 }
 
-func (bbp SkipTestNewContainer) MarshalBebop() []byte {
+func (bbp *SkipTestNewContainer) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/map_types.go
+++ b/testdata/generated/map_types.go
@@ -15,7 +15,7 @@ type S struct {
 	y int32
 }
 
-func (bbp S) MarshalBebopTo(buf []byte) int {
+func (bbp *S) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.x)
 	at += 4
@@ -47,7 +47,7 @@ func (bbp *S) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp S) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *S) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteInt32(w, bbp.x)
 	iohelp.WriteInt32(w, bbp.y)
@@ -61,14 +61,14 @@ func (bbp *S) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp S) Size() int {
+func (bbp *S) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp S) MarshalBebop() []byte {
+func (bbp *S) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -92,11 +92,11 @@ func MustMakeSFromBytes(buf []byte) S {
 	return v
 }
 
-func (bbp S) GetX() int32 {
+func (bbp *S) GetX() int32 {
 	return bbp.x
 }
 
-func (bbp S) GetY() int32 {
+func (bbp *S) GetY() int32 {
 	return bbp.y
 }
 
@@ -120,7 +120,7 @@ type SomeMaps struct {
 	M5 map[[16]byte]M
 }
 
-func (bbp SomeMaps) MarshalBebopTo(buf []byte) int {
+func (bbp *SomeMaps) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.M1)))
 	at += 4
@@ -404,7 +404,7 @@ func (bbp *SomeMaps) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp SomeMaps) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *SomeMaps) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.M1)))
 	for k1, v1 := range bbp.M1 {
@@ -527,7 +527,7 @@ func (bbp *SomeMaps) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp SomeMaps) Size() int {
+func (bbp *SomeMaps) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for range bbp.M1 {
@@ -575,7 +575,7 @@ func (bbp SomeMaps) Size() int {
 	return bodyLen
 }
 
-func (bbp SomeMaps) MarshalBebop() []byte {
+func (bbp *SomeMaps) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -722,7 +722,7 @@ func (bbp M) Size() int {
 	return bodyLen
 }
 
-func (bbp M) MarshalBebop() []byte {
+func (bbp *M) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/message_1.go
+++ b/testdata/generated/message_1.go
@@ -162,7 +162,7 @@ func (bbp ExampleMessage) Size() int {
 	return bodyLen
 }
 
-func (bbp ExampleMessage) MarshalBebop() []byte {
+func (bbp *ExampleMessage) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/message_map.go
+++ b/testdata/generated/message_map.go
@@ -138,7 +138,7 @@ func (bbp ReadOnlyMap) Size() int {
 	return bodyLen
 }
 
-func (bbp ReadOnlyMap) MarshalBebop() []byte {
+func (bbp *ReadOnlyMap) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/msgpack_comparison.go
+++ b/testdata/generated/msgpack_comparison.go
@@ -37,7 +37,7 @@ type MsgpackComparison struct {
 	ARRAY8 []int32
 }
 
-func (bbp MsgpackComparison) MarshalBebopTo(buf []byte) int {
+func (bbp *MsgpackComparison) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint8Bytes(buf[at:], bbp.INT0)
 	at += 1
@@ -291,7 +291,7 @@ func (bbp *MsgpackComparison) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp MsgpackComparison) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *MsgpackComparison) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint8(w, bbp.INT0)
 	iohelp.WriteUint8(w, bbp.INT1)
@@ -367,7 +367,7 @@ func (bbp *MsgpackComparison) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp MsgpackComparison) Size() int {
+func (bbp *MsgpackComparison) Size() int {
 	bodyLen := 0
 	bodyLen += 1
 	bodyLen += 1
@@ -398,7 +398,7 @@ func (bbp MsgpackComparison) Size() int {
 	return bodyLen
 }
 
-func (bbp MsgpackComparison) MarshalBebop() []byte {
+func (bbp *MsgpackComparison) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/quoted_string.go
+++ b/testdata/generated/quoted_string.go
@@ -19,7 +19,7 @@ type QuotedString struct {
 	Z int32
 }
 
-func (bbp QuotedString) MarshalBebopTo(buf []byte) int {
+func (bbp *QuotedString) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.X)
 	at += 4
@@ -60,7 +60,7 @@ func (bbp *QuotedString) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp QuotedString) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *QuotedString) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteInt32(w, bbp.X)
 	iohelp.WriteInt32(w, bbp.Y)
@@ -76,7 +76,7 @@ func (bbp *QuotedString) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp QuotedString) Size() int {
+func (bbp *QuotedString) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += 4
@@ -84,7 +84,7 @@ func (bbp QuotedString) Size() int {
 	return bodyLen
 }
 
-func (bbp QuotedString) MarshalBebop() []byte {
+func (bbp *QuotedString) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/request.go
+++ b/testdata/generated/request.go
@@ -24,7 +24,7 @@ type Furniture struct {
 	family FurnitureFamily
 }
 
-func (bbp Furniture) MarshalBebopTo(buf []byte) int {
+func (bbp *Furniture) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.name)))
 	copy(buf[at+4:at+4+len(bbp.name)], []byte(bbp.name))
@@ -63,7 +63,7 @@ func (bbp *Furniture) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp Furniture) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Furniture) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.name)))
 	w.Write([]byte(bbp.name))
@@ -80,7 +80,7 @@ func (bbp *Furniture) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Furniture) Size() int {
+func (bbp *Furniture) Size() int {
 	bodyLen := 0
 	bodyLen += 4 + len(bbp.name)
 	bodyLen += 4
@@ -88,7 +88,7 @@ func (bbp Furniture) Size() int {
 	return bodyLen
 }
 
-func (bbp Furniture) MarshalBebop() []byte {
+func (bbp *Furniture) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -112,15 +112,15 @@ func MustMakeFurnitureFromBytes(buf []byte) Furniture {
 	return v
 }
 
-func (bbp Furniture) GetName() string {
+func (bbp *Furniture) GetName() string {
 	return bbp.name
 }
 
-func (bbp Furniture) GetPrice() uint32 {
+func (bbp *Furniture) GetPrice() uint32 {
 	return bbp.price
 }
 
-func (bbp Furniture) GetFamily() FurnitureFamily {
+func (bbp *Furniture) GetFamily() FurnitureFamily {
 	return bbp.family
 }
 
@@ -144,7 +144,7 @@ type RequestResponse struct {
 	availableFurniture []Furniture
 }
 
-func (bbp RequestResponse) MarshalBebopTo(buf []byte) int {
+func (bbp *RequestResponse) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.availableFurniture)))
 	at += 4
@@ -182,7 +182,7 @@ func (bbp *RequestResponse) MustUnmarshalBebop(buf []byte) {
 	}
 }
 
-func (bbp RequestResponse) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *RequestResponse) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.availableFurniture)))
 	for _, elem := range bbp.availableFurniture {
@@ -206,7 +206,7 @@ func (bbp *RequestResponse) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp RequestResponse) Size() int {
+func (bbp *RequestResponse) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	for _, elem := range bbp.availableFurniture {
@@ -215,7 +215,7 @@ func (bbp RequestResponse) Size() int {
 	return bodyLen
 }
 
-func (bbp RequestResponse) MarshalBebop() []byte {
+func (bbp *RequestResponse) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -239,7 +239,7 @@ func MustMakeRequestResponseFromBytes(buf []byte) RequestResponse {
 	return v
 }
 
-func (bbp RequestResponse) GetAvailableFurniture() []Furniture {
+func (bbp *RequestResponse) GetAvailableFurniture() []Furniture {
 	return bbp.availableFurniture
 }
 
@@ -360,7 +360,7 @@ func (bbp RequestCatalog) Size() int {
 	return bodyLen
 }
 
-func (bbp RequestCatalog) MarshalBebop() []byte {
+func (bbp *RequestCatalog) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/server.go
+++ b/testdata/generated/server.go
@@ -14,7 +14,7 @@ type Print struct {
 	Printout string
 }
 
-func (bbp Print) MarshalBebopTo(buf []byte) int {
+func (bbp *Print) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.Printout)))
 	copy(buf[at+4:at+4+len(bbp.Printout)], []byte(bbp.Printout))
@@ -38,7 +38,7 @@ func (bbp *Print) MustUnmarshalBebop(buf []byte) {
 	at += 4 + len(bbp.Printout)
 }
 
-func (bbp Print) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Print) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.Printout)))
 	w.Write([]byte(bbp.Printout))
@@ -51,13 +51,13 @@ func (bbp *Print) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Print) Size() int {
+func (bbp *Print) Size() int {
 	bodyLen := 0
 	bodyLen += 4 + len(bbp.Printout)
 	return bodyLen
 }
 
-func (bbp Print) MarshalBebop() []byte {
+func (bbp *Print) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -88,7 +88,7 @@ type Add struct {
 	B int32
 }
 
-func (bbp Add) MarshalBebopTo(buf []byte) int {
+func (bbp *Add) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.A)
 	at += 4
@@ -120,7 +120,7 @@ func (bbp *Add) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp Add) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Add) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteInt32(w, bbp.A)
 	iohelp.WriteInt32(w, bbp.B)
@@ -134,14 +134,14 @@ func (bbp *Add) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Add) Size() int {
+func (bbp *Add) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp Add) MarshalBebop() []byte {
+func (bbp *Add) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -171,7 +171,7 @@ type AddResponse struct {
 	C int32
 }
 
-func (bbp AddResponse) MarshalBebopTo(buf []byte) int {
+func (bbp *AddResponse) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteInt32Bytes(buf[at:], bbp.C)
 	at += 4
@@ -194,7 +194,7 @@ func (bbp *AddResponse) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp AddResponse) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *AddResponse) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteInt32(w, bbp.C)
 	return w.Err
@@ -206,13 +206,13 @@ func (bbp *AddResponse) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp AddResponse) Size() int {
+func (bbp *AddResponse) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp AddResponse) MarshalBebop() []byte {
+func (bbp *AddResponse) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -336,7 +336,7 @@ func (bbp PrintRequest) Size() int {
 	return bodyLen
 }
 
-func (bbp PrintRequest) MarshalBebop() []byte {
+func (bbp *PrintRequest) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -460,7 +460,7 @@ func (bbp AddRequest) Size() int {
 	return bodyLen
 }
 
-func (bbp AddRequest) MarshalBebop() []byte {
+func (bbp *AddRequest) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/tags.go
+++ b/testdata/generated/tags.go
@@ -14,7 +14,7 @@ type TaggedStruct struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-func (bbp TaggedStruct) MarshalBebopTo(buf []byte) int {
+func (bbp *TaggedStruct) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.Foo)))
 	copy(buf[at+4:at+4+len(bbp.Foo)], []byte(bbp.Foo))
@@ -38,7 +38,7 @@ func (bbp *TaggedStruct) MustUnmarshalBebop(buf []byte) {
 	at += 4 + len(bbp.Foo)
 }
 
-func (bbp TaggedStruct) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *TaggedStruct) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.Foo)))
 	w.Write([]byte(bbp.Foo))
@@ -51,13 +51,13 @@ func (bbp *TaggedStruct) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp TaggedStruct) Size() int {
+func (bbp *TaggedStruct) Size() int {
 	bodyLen := 0
 	bodyLen += 4 + len(bbp.Foo)
 	return bodyLen
 }
 
-func (bbp TaggedStruct) MarshalBebop() []byte {
+func (bbp *TaggedStruct) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -173,7 +173,7 @@ func (bbp TaggedMessage) Size() int {
 	return bodyLen
 }
 
-func (bbp TaggedMessage) MarshalBebop() []byte {
+func (bbp *TaggedMessage) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -203,7 +203,7 @@ type TaggedSubStruct struct {
 	Biz [16]byte `four:"four"`
 }
 
-func (bbp TaggedSubStruct) MarshalBebopTo(buf []byte) int {
+func (bbp *TaggedSubStruct) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteGUIDBytes(buf[at:], bbp.Biz)
 	at += 16
@@ -226,7 +226,7 @@ func (bbp *TaggedSubStruct) MustUnmarshalBebop(buf []byte) {
 	at += 16
 }
 
-func (bbp TaggedSubStruct) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *TaggedSubStruct) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteGUID(w, bbp.Biz)
 	return w.Err
@@ -238,13 +238,13 @@ func (bbp *TaggedSubStruct) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp TaggedSubStruct) Size() int {
+func (bbp *TaggedSubStruct) Size() int {
 	bodyLen := 0
 	bodyLen += 16
 	return bodyLen
 }
 
-func (bbp TaggedSubStruct) MarshalBebop() []byte {
+func (bbp *TaggedSubStruct) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -375,7 +375,7 @@ func (bbp TaggedUnion) Size() int {
 	return bodyLen
 }
 
-func (bbp TaggedUnion) MarshalBebop() []byte {
+func (bbp *TaggedUnion) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/union.go
+++ b/testdata/generated/union.go
@@ -100,7 +100,7 @@ func (bbp A) Size() int {
 	return bodyLen
 }
 
-func (bbp A) MarshalBebop() []byte {
+func (bbp *A) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -133,7 +133,7 @@ type B struct {
 	C bool
 }
 
-func (bbp B) MarshalBebopTo(buf []byte) int {
+func (bbp *B) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteBoolBytes(buf[at:], bbp.C)
 	at += 1
@@ -156,7 +156,7 @@ func (bbp *B) MustUnmarshalBebop(buf []byte) {
 	at += 1
 }
 
-func (bbp B) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *B) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteBool(w, bbp.C)
 	return w.Err
@@ -168,13 +168,13 @@ func (bbp *B) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp B) Size() int {
+func (bbp *B) Size() int {
 	bodyLen := 0
 	bodyLen += 1
 	return bodyLen
 }
 
-func (bbp B) MarshalBebop() []byte {
+func (bbp *B) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -203,7 +203,7 @@ var _ bebop.Record = &C{}
 type C struct {
 }
 
-func (bbp C) MarshalBebopTo(buf []byte) int {
+func (bbp *C) MarshalBebopTo(buf []byte) int {
 	return 0
 }
 
@@ -214,7 +214,7 @@ func (bbp *C) UnmarshalBebop(buf []byte) (err error) {
 func (bbp *C) MustUnmarshalBebop(buf []byte) {
 }
 
-func (bbp C) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *C) EncodeBebop(iow io.Writer) (err error) {
 	return nil
 }
 
@@ -222,11 +222,11 @@ func (bbp *C) DecodeBebop(ior io.Reader) (err error) {
 	return nil
 }
 
-func (bbp C) Size() int {
+func (bbp *C) Size() int {
 	return 0
 }
 
-func (bbp C) MarshalBebop() []byte {
+func (bbp *C) MarshalBebop() []byte {
 	return []byte{}
 }
 
@@ -442,7 +442,7 @@ func (bbp U) Size() int {
 	return bodyLen
 }
 
-func (bbp U) MarshalBebop() []byte {
+func (bbp *U) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -473,7 +473,7 @@ type Cons struct {
 	Tail List
 }
 
-func (bbp Cons) MarshalBebopTo(buf []byte) int {
+func (bbp *Cons) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], bbp.Head)
 	at += 4
@@ -505,7 +505,7 @@ func (bbp *Cons) MustUnmarshalBebop(buf []byte) {
 	at += (bbp.Tail).Size()
 }
 
-func (bbp Cons) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Cons) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, bbp.Head)
 	err = (bbp.Tail).EncodeBebop(w)
@@ -525,14 +525,14 @@ func (bbp *Cons) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Cons) Size() int {
+func (bbp *Cons) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	bodyLen += (bbp.Tail).Size()
 	return bodyLen
 }
 
-func (bbp Cons) MarshalBebop() []byte {
+func (bbp *Cons) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -562,7 +562,7 @@ var _ bebop.Record = &Null{}
 type Null struct {
 }
 
-func (bbp Null) MarshalBebopTo(buf []byte) int {
+func (bbp *Null) MarshalBebopTo(buf []byte) int {
 	return 0
 }
 
@@ -573,7 +573,7 @@ func (bbp *Null) UnmarshalBebop(buf []byte) (err error) {
 func (bbp *Null) MustUnmarshalBebop(buf []byte) {
 }
 
-func (bbp Null) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Null) EncodeBebop(iow io.Writer) (err error) {
 	return nil
 }
 
@@ -581,11 +581,11 @@ func (bbp *Null) DecodeBebop(ior io.Reader) (err error) {
 	return nil
 }
 
-func (bbp Null) Size() int {
+func (bbp *Null) Size() int {
 	return 0
 }
 
-func (bbp Null) MarshalBebop() []byte {
+func (bbp *Null) MarshalBebop() []byte {
 	return []byte{}
 }
 
@@ -752,7 +752,7 @@ func (bbp List) Size() int {
 	return bodyLen
 }
 
-func (bbp List) MarshalBebop() []byte {
+func (bbp *List) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/generated/union_field.go
+++ b/testdata/generated/union_field.go
@@ -106,7 +106,7 @@ func (bbp WithUnionField) Size() int {
 	return bodyLen
 }
 
-func (bbp WithUnionField) MarshalBebop() []byte {
+func (bbp *WithUnionField) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -137,7 +137,7 @@ type Cons2 struct {
 	Tail List
 }
 
-func (bbp Cons2) MarshalBebopTo(buf []byte) int {
+func (bbp *Cons2) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], bbp.Head)
 	at += 4
@@ -163,7 +163,7 @@ func (bbp *Cons2) MustUnmarshalBebop(buf []byte) {
 	
 }
 
-func (bbp Cons2) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Cons2) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, bbp.Head)
 	
@@ -177,14 +177,14 @@ func (bbp *Cons2) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp Cons2) Size() int {
+func (bbp *Cons2) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	
 	return bodyLen
 }
 
-func (bbp Cons2) MarshalBebop() []byte {
+func (bbp *Cons2) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -214,7 +214,7 @@ var _ bebop.Record = &Nil2{}
 type Nil2 struct {
 }
 
-func (bbp Nil2) MarshalBebopTo(buf []byte) int {
+func (bbp *Nil2) MarshalBebopTo(buf []byte) int {
 	return 0
 }
 
@@ -225,7 +225,7 @@ func (bbp *Nil2) UnmarshalBebop(buf []byte) (err error) {
 func (bbp *Nil2) MustUnmarshalBebop(buf []byte) {
 }
 
-func (bbp Nil2) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Nil2) EncodeBebop(iow io.Writer) (err error) {
 	return nil
 }
 
@@ -233,11 +233,11 @@ func (bbp *Nil2) DecodeBebop(ior io.Reader) (err error) {
 	return nil
 }
 
-func (bbp Nil2) Size() int {
+func (bbp *Nil2) Size() int {
 	return 0
 }
 
-func (bbp Nil2) MarshalBebop() []byte {
+func (bbp *Nil2) MarshalBebop() []byte {
 	return []byte{}
 }
 
@@ -404,7 +404,7 @@ func (bbp List2) Size() int {
 	return bodyLen
 }
 
-func (bbp List2) MarshalBebop() []byte {
+func (bbp *List2) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/incompatible/generated/import_separate_a.go
+++ b/testdata/incompatible/generated/import_separate_a.go
@@ -19,7 +19,7 @@ type UsesImport struct {
 	Imported generatedtwo.ImportedType
 }
 
-func (bbp UsesImport) MarshalBebopTo(buf []byte) int {
+func (bbp *UsesImport) MarshalBebopTo(buf []byte) int {
 	at := 0
 	(bbp.Imported).MarshalBebopTo(buf[at:])
 	at += (bbp.Imported).Size()
@@ -42,7 +42,7 @@ func (bbp *UsesImport) MustUnmarshalBebop(buf []byte) {
 	at += (bbp.Imported).Size()
 }
 
-func (bbp UsesImport) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *UsesImport) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	err = (bbp.Imported).EncodeBebop(w)
 	if err != nil {
@@ -60,13 +60,13 @@ func (bbp *UsesImport) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp UsesImport) Size() int {
+func (bbp *UsesImport) Size() int {
 	bodyLen := 0
 	bodyLen += (bbp.Imported).Size()
 	return bodyLen
 }
 
-func (bbp UsesImport) MarshalBebop() []byte {
+func (bbp *UsesImport) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -188,7 +188,7 @@ func (bbp UsesImportMsg) Size() int {
 	return bodyLen
 }
 
-func (bbp UsesImportMsg) MarshalBebop() []byte {
+func (bbp *UsesImportMsg) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -218,7 +218,7 @@ type UnionStruct struct {
 	Hello generatedtwo.ImportedEnum
 }
 
-func (bbp UnionStruct) MarshalBebopTo(buf []byte) int {
+func (bbp *UnionStruct) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(bbp.Hello))
 	at += 4
@@ -238,7 +238,7 @@ func (bbp *UnionStruct) MustUnmarshalBebop(buf []byte) {
 	at += 4
 }
 
-func (bbp UnionStruct) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *UnionStruct) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(bbp.Hello))
 	return w.Err
@@ -250,13 +250,13 @@ func (bbp *UnionStruct) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp UnionStruct) Size() int {
+func (bbp *UnionStruct) Size() int {
 	bodyLen := 0
 	bodyLen += 4
 	return bodyLen
 }
 
-func (bbp UnionStruct) MarshalBebop() []byte {
+func (bbp *UnionStruct) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -369,7 +369,7 @@ func (bbp UnionMessage) Size() int {
 	return bodyLen
 }
 
-func (bbp UnionMessage) MarshalBebop() []byte {
+func (bbp *UnionMessage) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -544,7 +544,7 @@ func (bbp UsesImportUnion) Size() int {
 	return bodyLen
 }
 
-func (bbp UsesImportUnion) MarshalBebop() []byte {
+func (bbp *UsesImportUnion) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf

--- a/testdata/incompatible/generatedthree/import_separate_c.go
+++ b/testdata/incompatible/generatedthree/import_separate_c.go
@@ -17,7 +17,7 @@ var _ bebop.Record = &NotImported{}
 type NotImported struct {
 }
 
-func (bbp NotImported) MarshalBebopTo(buf []byte) int {
+func (bbp *NotImported) MarshalBebopTo(buf []byte) int {
 	return 0
 }
 
@@ -28,7 +28,7 @@ func (bbp *NotImported) UnmarshalBebop(buf []byte) (err error) {
 func (bbp *NotImported) MustUnmarshalBebop(buf []byte) {
 }
 
-func (bbp NotImported) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *NotImported) EncodeBebop(iow io.Writer) (err error) {
 	return nil
 }
 
@@ -36,11 +36,11 @@ func (bbp *NotImported) DecodeBebop(ior io.Reader) (err error) {
 	return nil
 }
 
-func (bbp NotImported) Size() int {
+func (bbp *NotImported) Size() int {
 	return 0
 }
 
-func (bbp NotImported) MarshalBebop() []byte {
+func (bbp *NotImported) MarshalBebop() []byte {
 	return []byte{}
 }
 

--- a/testdata/incompatible/generatedtwo/import_separate_b.go
+++ b/testdata/incompatible/generatedtwo/import_separate_b.go
@@ -24,7 +24,7 @@ type ImportedType struct {
 	Foobar string
 }
 
-func (bbp ImportedType) MarshalBebopTo(buf []byte) int {
+func (bbp *ImportedType) MarshalBebopTo(buf []byte) int {
 	at := 0
 	iohelp.WriteUint32Bytes(buf[at:], uint32(len(bbp.Foobar)))
 	copy(buf[at+4:at+4+len(bbp.Foobar)], []byte(bbp.Foobar))
@@ -48,7 +48,7 @@ func (bbp *ImportedType) MustUnmarshalBebop(buf []byte) {
 	at += 4 + len(bbp.Foobar)
 }
 
-func (bbp ImportedType) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *ImportedType) EncodeBebop(iow io.Writer) (err error) {
 	w := iohelp.NewErrorWriter(iow)
 	iohelp.WriteUint32(w, uint32(len(bbp.Foobar)))
 	w.Write([]byte(bbp.Foobar))
@@ -61,13 +61,13 @@ func (bbp *ImportedType) DecodeBebop(ior io.Reader) (err error) {
 	return r.Err
 }
 
-func (bbp ImportedType) Size() int {
+func (bbp *ImportedType) Size() int {
 	bodyLen := 0
 	bodyLen += 4 + len(bbp.Foobar)
 	return bodyLen
 }
 
-func (bbp ImportedType) MarshalBebop() []byte {
+func (bbp *ImportedType) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -254,7 +254,7 @@ func (bbp ImportedMessage) Size() int {
 	return bodyLen
 }
 
-func (bbp ImportedMessage) MarshalBebop() []byte {
+func (bbp *ImportedMessage) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf
@@ -339,7 +339,7 @@ func (bbp WhyAreTheseInline) Size() int {
 	return bodyLen
 }
 
-func (bbp WhyAreTheseInline) MarshalBebop() []byte {
+func (bbp *WhyAreTheseInline) MarshalBebop() []byte {
 	return []byte{}
 }
 
@@ -360,7 +360,7 @@ var _ bebop.Record = &Really{}
 type Really struct {
 }
 
-func (bbp Really) MarshalBebopTo(buf []byte) int {
+func (bbp *Really) MarshalBebopTo(buf []byte) int {
 	return 0
 }
 
@@ -371,7 +371,7 @@ func (bbp *Really) UnmarshalBebop(buf []byte) (err error) {
 func (bbp *Really) MustUnmarshalBebop(buf []byte) {
 }
 
-func (bbp Really) EncodeBebop(iow io.Writer) (err error) {
+func (bbp *Really) EncodeBebop(iow io.Writer) (err error) {
 	return nil
 }
 
@@ -379,11 +379,11 @@ func (bbp *Really) DecodeBebop(ior io.Reader) (err error) {
 	return nil
 }
 
-func (bbp Really) Size() int {
+func (bbp *Really) Size() int {
 	return 0
 }
 
-func (bbp Really) MarshalBebop() []byte {
+func (bbp *Really) MarshalBebop() []byte {
 	return []byte{}
 }
 
@@ -550,7 +550,7 @@ func (bbp ImportedUnion) Size() int {
 	return bodyLen
 }
 
-func (bbp ImportedUnion) MarshalBebop() []byte {
+func (bbp *ImportedUnion) MarshalBebop() []byte {
 	buf := make([]byte, bbp.Size())
 	bbp.MarshalBebopTo(buf)
 	return buf


### PR DESCRIPTION
Changed for Encoding, Marshalling, Getters and Size methods.

Rationale is that on non-pointer receivers will cause the objects to be copied as part of method invocation. That causes additional allocs and pressure on the GC. For applications which do a lot of serialisation, this may well be noticable - a lot of performance tuning in Go focuses on optimising memory usage.

All tests still pass.