### PR TITLE
avoid reading/writing byte-by-byte in a loop

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -680,9 +680,13 @@ func writeFieldReadByter(name string, typ FieldType, w io.Writer, settings Gener
 func writeFieldMarshaller(name string, typ FieldType, w io.Writer, settings GenerateSettings, depth int) {
 	if typ.Array != nil {
 		writeLineWithTabs(w, "iohelp.WriteUint32(w, uint32(len(%ASGN)))", depth, name)
-		writeLineWithTabs(w, "for _, elem := range %ASGN {", depth, name)
-		writeFieldMarshaller("elem", *typ.Array, w, settings, depth+1)
-		writeLineWithTabs(w, "}", depth)
+		if typ.Array.Simple == typeByte {
+			writeLineWithTabs(w, "w.Write(%ASGN)", depth, name)
+		} else {
+			writeLineWithTabs(w, "for _, elem := range %ASGN {", depth, name)
+			writeFieldMarshaller("elem", *typ.Array, w, settings, depth+1)
+			writeLineWithTabs(w, "}", depth)
+		}
 	} else if typ.Map != nil {
 		writeLineWithTabs(w, "iohelp.WriteUint32(w, uint32(len(%ASGN)))", depth, name)
 		writeLineWithTabs(w, "for %KNAME, %VNAME := range %ASGN {", depth, name)
@@ -834,7 +838,7 @@ func writeLine(w io.Writer, format string, args ...interface{}) {
 }
 
 func getLineWithTabs(format string, depth int, args ...string) string {
-	var b = new(bytes.Buffer)
+	b := new(bytes.Buffer)
 	writeLineWithTabs(b, format, depth, args...)
 	return b.String()
 }

--- a/gen_message.go
+++ b/gen_message.go
@@ -179,9 +179,13 @@ func (msg Message) Generate(w io.Writer, settings GenerateSettings) {
 func writeMessageFieldUnmarshaller(name string, typ FieldType, w io.Writer, settings GenerateSettings, depth int) {
 	if typ.Array != nil {
 		writeLineWithTabs(w, "%RECV = make([]%TYPE, iohelp.ReadUint32(r))", depth, name, typ.Array.goString(settings))
-		writeLineWithTabs(w, "for i := range %RECV {", depth, name)
-		writeMessageFieldUnmarshaller("("+name+")[i]", *typ.Array, w, settings, depth+1)
-		writeLineWithTabs(w, "}", depth)
+		if typ.Array.Simple == typeByte {
+			writeLineWithTabs(w, "r.Read(%RECV)", depth, name)
+		} else {
+			writeLineWithTabs(w, "for i := range %RECV {", depth, name)
+			writeMessageFieldUnmarshaller("("+name+")[i]", *typ.Array, w, settings, depth+1)
+			writeLineWithTabs(w, "}", depth)
+		}
 	} else if typ.Map != nil {
 		lnName := depthName("ln", depth)
 		writeLineWithTabs(w, lnName+" := iohelp.ReadUint32(r)", depth)

--- a/gen_struct.go
+++ b/gen_struct.go
@@ -176,10 +176,14 @@ func writeStructFieldUnmarshaller(name string, typ FieldType, w io.Writer, setti
 	iName := "i" + strconv.Itoa(depth)
 	if typ.Array != nil {
 		writeLineWithTabs(w, "%RECV = make([]%TYPE, iohelp.ReadUint32(r))", depth, name, typ.Array.goString(settings))
-		writeLineWithTabs(w, "for "+iName+" := range %RECV {", depth, name)
-		name = "&(" + name[1:] + "[" + iName + "])"
-		writeStructFieldUnmarshaller(name, *typ.Array, w, settings, depth+1)
-		writeLineWithTabs(w, "}", depth)
+		if typ.Array.Simple == typeByte {
+			writeLineWithTabs(w, "r.Read(%RECV)", depth, name)
+		} else {
+			writeLineWithTabs(w, "for "+iName+" := range %RECV {", depth, name)
+			name = "&(" + name[1:] + "[" + iName + "])"
+			writeStructFieldUnmarshaller(name, *typ.Array, w, settings, depth+1)
+			writeLineWithTabs(w, "}", depth)
+		}
 	} else if typ.Map != nil {
 		lnName := "ln" + strconv.Itoa(depth)
 		if *settings.isFirstTopLength && depth == 1 {

--- a/testdata/generated-private/arrays.go
+++ b/testdata/generated-private/arrays.go
@@ -132,9 +132,7 @@ func (bbp arraySamples) EncodeBebop(iow io.Writer) (err error) {
 		iohelp.WriteUint32(w, uint32(len(elem)))
 		for _, elem := range elem {
 			iohelp.WriteUint32(w, uint32(len(elem)))
-			for _, elem := range elem {
-				iohelp.WriteByte(w, elem)
-			}
+			w.Write(elem)
 		}
 	}
 	iohelp.WriteUint32(w, uint32(len(bbp.bytes2)))
@@ -142,9 +140,7 @@ func (bbp arraySamples) EncodeBebop(iow io.Writer) (err error) {
 		iohelp.WriteUint32(w, uint32(len(elem)))
 		for _, elem := range elem {
 			iohelp.WriteUint32(w, uint32(len(elem)))
-			for _, elem := range elem {
-				iohelp.WriteByte(w, elem)
-			}
+			w.Write(elem)
 		}
 	}
 	return w.Err
@@ -157,9 +153,7 @@ func (bbp *arraySamples) DecodeBebop(ior io.Reader) (err error) {
 		(bbp.bytes[i1]) = make([][]byte, iohelp.ReadUint32(r))
 		for i2 := range (bbp.bytes[i1]) {
 			((bbp.bytes[i1])[i2]) = make([]byte, iohelp.ReadUint32(r))
-			for i3 := range ((bbp.bytes[i1])[i2]) {
-				(((bbp.bytes[i1])[i2])[i3]) = iohelp.ReadByte(r)
-			}
+			r.Read(((bbp.bytes[i1])[i2]))
 		}
 	}
 	bbp.bytes2 = make([][][]byte, iohelp.ReadUint32(r))
@@ -167,9 +161,7 @@ func (bbp *arraySamples) DecodeBebop(ior io.Reader) (err error) {
 		(bbp.bytes2[i1]) = make([][]byte, iohelp.ReadUint32(r))
 		for i2 := range (bbp.bytes2[i1]) {
 			((bbp.bytes2[i1])[i2]) = make([]byte, iohelp.ReadUint32(r))
-			for i3 := range ((bbp.bytes2[i1])[i2]) {
-				(((bbp.bytes2[i1])[i2])[i3]) = iohelp.ReadByte(r)
-			}
+			r.Read(((bbp.bytes2[i1])[i2]))
 		}
 	}
 	return r.Err

--- a/testdata/generated-private/basic_arrays.go
+++ b/testdata/generated-private/basic_arrays.go
@@ -329,9 +329,7 @@ func (bbp basicArrays) EncodeBebop(iow io.Writer) (err error) {
 		iohelp.WriteBool(w, elem)
 	}
 	iohelp.WriteUint32(w, uint32(len(bbp.a_byte)))
-	for _, elem := range bbp.a_byte {
-		iohelp.WriteByte(w, elem)
-	}
+	w.Write(bbp.a_byte)
 	iohelp.WriteUint32(w, uint32(len(bbp.a_int16)))
 	for _, elem := range bbp.a_int16 {
 		iohelp.WriteInt16(w, elem)
@@ -383,9 +381,7 @@ func (bbp *basicArrays) DecodeBebop(ior io.Reader) (err error) {
 		(bbp.a_bool[i1]) = iohelp.ReadBool(r)
 	}
 	bbp.a_byte = make([]byte, iohelp.ReadUint32(r))
-	for i1 := range bbp.a_byte {
-		(bbp.a_byte[i1]) = iohelp.ReadByte(r)
-	}
+	r.Read(bbp.a_byte)
 	bbp.a_int16 = make([]int16, iohelp.ReadUint32(r))
 	for i1 := range bbp.a_int16 {
 		(bbp.a_int16[i1]) = iohelp.ReadInt16(r)

--- a/testdata/generated-private/lab.go
+++ b/testdata/generated-private/lab.go
@@ -647,9 +647,7 @@ func (bbp videoData) EncodeBebop(iow io.Writer) (err error) {
 	iohelp.WriteUint32(w, bbp.width)
 	iohelp.WriteUint32(w, bbp.height)
 	iohelp.WriteUint32(w, uint32(len(bbp.fragment)))
-	for _, elem := range bbp.fragment {
-		iohelp.WriteByte(w, elem)
-	}
+	w.Write(bbp.fragment)
 	return w.Err
 }
 
@@ -659,9 +657,7 @@ func (bbp *videoData) DecodeBebop(ior io.Reader) (err error) {
 	bbp.width = iohelp.ReadUint32(r)
 	bbp.height = iohelp.ReadUint32(r)
 	bbp.fragment = make([]byte, iohelp.ReadUint32(r))
-	for i1 := range bbp.fragment {
-		(bbp.fragment[i1]) = iohelp.ReadByte(r)
-	}
+	r.Read(bbp.fragment)
 	return r.Err
 }
 

--- a/testdata/generated/arrays.go
+++ b/testdata/generated/arrays.go
@@ -132,9 +132,7 @@ func (bbp ArraySamples) EncodeBebop(iow io.Writer) (err error) {
 		iohelp.WriteUint32(w, uint32(len(elem)))
 		for _, elem := range elem {
 			iohelp.WriteUint32(w, uint32(len(elem)))
-			for _, elem := range elem {
-				iohelp.WriteByte(w, elem)
-			}
+			w.Write(elem)
 		}
 	}
 	iohelp.WriteUint32(w, uint32(len(bbp.Bytes2)))
@@ -142,9 +140,7 @@ func (bbp ArraySamples) EncodeBebop(iow io.Writer) (err error) {
 		iohelp.WriteUint32(w, uint32(len(elem)))
 		for _, elem := range elem {
 			iohelp.WriteUint32(w, uint32(len(elem)))
-			for _, elem := range elem {
-				iohelp.WriteByte(w, elem)
-			}
+			w.Write(elem)
 		}
 	}
 	return w.Err
@@ -157,9 +153,7 @@ func (bbp *ArraySamples) DecodeBebop(ior io.Reader) (err error) {
 		(bbp.Bytes[i1]) = make([][]byte, iohelp.ReadUint32(r))
 		for i2 := range (bbp.Bytes[i1]) {
 			((bbp.Bytes[i1])[i2]) = make([]byte, iohelp.ReadUint32(r))
-			for i3 := range ((bbp.Bytes[i1])[i2]) {
-				(((bbp.Bytes[i1])[i2])[i3]) = iohelp.ReadByte(r)
-			}
+			r.Read(((bbp.Bytes[i1])[i2]))
 		}
 	}
 	bbp.Bytes2 = make([][][]byte, iohelp.ReadUint32(r))
@@ -167,9 +161,7 @@ func (bbp *ArraySamples) DecodeBebop(ior io.Reader) (err error) {
 		(bbp.Bytes2[i1]) = make([][]byte, iohelp.ReadUint32(r))
 		for i2 := range (bbp.Bytes2[i1]) {
 			((bbp.Bytes2[i1])[i2]) = make([]byte, iohelp.ReadUint32(r))
-			for i3 := range ((bbp.Bytes2[i1])[i2]) {
-				(((bbp.Bytes2[i1])[i2])[i3]) = iohelp.ReadByte(r)
-			}
+			r.Read(((bbp.Bytes2[i1])[i2]))
 		}
 	}
 	return r.Err

--- a/testdata/generated/basic_arrays.go
+++ b/testdata/generated/basic_arrays.go
@@ -329,9 +329,7 @@ func (bbp BasicArrays) EncodeBebop(iow io.Writer) (err error) {
 		iohelp.WriteBool(w, elem)
 	}
 	iohelp.WriteUint32(w, uint32(len(bbp.A_byte)))
-	for _, elem := range bbp.A_byte {
-		iohelp.WriteByte(w, elem)
-	}
+	w.Write(bbp.A_byte)
 	iohelp.WriteUint32(w, uint32(len(bbp.A_int16)))
 	for _, elem := range bbp.A_int16 {
 		iohelp.WriteInt16(w, elem)
@@ -383,9 +381,7 @@ func (bbp *BasicArrays) DecodeBebop(ior io.Reader) (err error) {
 		(bbp.A_bool[i1]) = iohelp.ReadBool(r)
 	}
 	bbp.A_byte = make([]byte, iohelp.ReadUint32(r))
-	for i1 := range bbp.A_byte {
-		(bbp.A_byte[i1]) = iohelp.ReadByte(r)
-	}
+	r.Read(bbp.A_byte)
 	bbp.A_int16 = make([]int16, iohelp.ReadUint32(r))
 	for i1 := range bbp.A_int16 {
 		(bbp.A_int16[i1]) = iohelp.ReadInt16(r)

--- a/testdata/generated/import_b/import_b.go
+++ b/testdata/generated/import_b/import_b.go
@@ -1023,9 +1023,7 @@ func (bbp VideoData) EncodeBebop(iow io.Writer) (err error) {
 	iohelp.WriteUint32(w, bbp.Width)
 	iohelp.WriteUint32(w, bbp.Height)
 	iohelp.WriteUint32(w, uint32(len(bbp.Fragment)))
-	for _, elem := range bbp.Fragment {
-		iohelp.WriteByte(w, elem)
-	}
+	w.Write(bbp.Fragment)
 	return w.Err
 }
 
@@ -1035,9 +1033,7 @@ func (bbp *VideoData) DecodeBebop(ior io.Reader) (err error) {
 	bbp.Width = iohelp.ReadUint32(r)
 	bbp.Height = iohelp.ReadUint32(r)
 	bbp.Fragment = make([]byte, iohelp.ReadUint32(r))
-	for i1 := range bbp.Fragment {
-		(bbp.Fragment[i1]) = iohelp.ReadByte(r)
-	}
+	r.Read(bbp.Fragment)
 	return r.Err
 }
 

--- a/testdata/generated/lab.go
+++ b/testdata/generated/lab.go
@@ -647,9 +647,7 @@ func (bbp VideoData) EncodeBebop(iow io.Writer) (err error) {
 	iohelp.WriteUint32(w, bbp.Width)
 	iohelp.WriteUint32(w, bbp.Height)
 	iohelp.WriteUint32(w, uint32(len(bbp.Fragment)))
-	for _, elem := range bbp.Fragment {
-		iohelp.WriteByte(w, elem)
-	}
+	w.Write(bbp.Fragment)
 	return w.Err
 }
 
@@ -659,9 +657,7 @@ func (bbp *VideoData) DecodeBebop(ior io.Reader) (err error) {
 	bbp.Width = iohelp.ReadUint32(r)
 	bbp.Height = iohelp.ReadUint32(r)
 	bbp.Fragment = make([]byte, iohelp.ReadUint32(r))
-	for i1 := range bbp.Fragment {
-		(bbp.Fragment[i1]) = iohelp.ReadByte(r)
-	}
+	r.Read(bbp.Fragment)
 	return r.Err
 }
 


### PR DESCRIPTION
Fix performance impact of reading/writing one byte at a time in a loop